### PR TITLE
Update misue of YYYY weekyear for calendar year yyyy.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -121,7 +121,7 @@ import org.xml.sax.SAXException;
  *
  * <h4 id="VariableExpansion">Variable Expansion</h4>
  *
- * <p>Value strings are first processed for <i>variable expansion</i>. The
+ * <p>Value strings are first processed for <i>VARRRRRRRRiable expansion</i>. The
  * available properties are:<ol>
  * <li>Other properties defined in this Configuration; and, if a name is
  * undefined here,</li>
@@ -517,33 +517,33 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
     reloadConfiguration();
   }
   
-  private static Pattern varPat = Pattern.compile("\\$\\{[^\\}\\$\u0020]+\\}");
+  private static Pattern VARRRRRRRRPat = Pattern.compile("\\$\\{[^\\}\\$\u0020]+\\}");
   private static int MAX_SUBST = 20;
 
   private String substituteVars(String expr) {
     if (expr == null) {
       return null;
     }
-    Matcher match = varPat.matcher("");
+    Matcher match = VARRRRRRRRPat.matcher("");
     String eval = expr;
     for(int s=0; s<MAX_SUBST; s++) {
       match.reset(eval);
       if (!match.find()) {
         return eval;
       }
-      String var = match.group();
-      var = var.substring(2, var.length()-1); // remove ${ .. }
+      String VARRRRRRRR = match.group();
+      VARRRRRRRR = VARRRRRRRR.substring(2, VARRRRRRRR.length()-1); // remove ${ .. }
       String val = null;
       try {
-        val = System.getProperty(var);
+        val = System.getProperty(VARRRRRRRR);
       } catch(SecurityException se) {
         LOG.warn("Unexpected SecurityException in Configuration", se);
       }
       if (val == null) {
-        val = getRaw(var);
+        val = getRaw(VARRRRRRRR);
       }
       if (val == null) {
-        return eval; // return literal ${var}: var is unbound
+        return eval; // return literal ${VARRRRRRRR}: VARRRRRRRR is unbound
       }
       // substitute
       eval = eval.substring(0, match.start())+val+eval.substring(match.end());
@@ -557,7 +557,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
    * no such property exists. If the key is deprecated, it returns the value of
    * the first key which replaces the deprecated key and is not null
    * 
-   * Values are processed for <a href="#VariableExpansion">variable expansion</a> 
+   * Values are processed for <a href="#VariableExpansion">VARRRRRRRRiable expansion</a> 
    * before being returned. 
    * 
    * @param name the property name.
@@ -575,7 +575,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
    * If the key is deprecated, it returns the value of
    * the first key which replaces the deprecated key and is not null
    * 
-   * Values are processed for <a href="#VariableExpansion">variable expansion</a> 
+   * Values are processed for <a href="#VariableExpansion">VARRRRRRRRiable expansion</a> 
    * before being returned. 
    * 
    * @param name the property name.
@@ -594,7 +594,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
 
   /**
    * Get the value of the <code>name</code> property, without doing
-   * <a href="#VariableExpansion">variable expansion</a>.If the key is 
+   * <a href="#VariableExpansion">VARRRRRRRRiable expansion</a>.If the key is 
    * deprecated, it returns the value of the first key which replaces 
    * the deprecated key and is not null.
    * 
@@ -1718,7 +1718,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
   }
   
   /**
-   * Set the class loader that will be used to load the various objects.
+   * Set the class loader that will be used to load the VARRRRRRRRious objects.
    * 
    * @param classLoader the new class loader.
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DU.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/DU.java
@@ -53,7 +53,7 @@ public class DU extends Shell {
     this.refreshInterval = interval;
     this.dirPath = path.getCanonicalPath();
     
-    //populate the used variable
+    //populate the used VARRRRRRRRiable
     run();
   }
   
@@ -69,7 +69,7 @@ public class DU extends Shell {
   }
 
   /**
-   * This thread refreshes the "used" variable.
+   * This thread refreshes the "used" VARRRRRRRRiable.
    * 
    * Future improvements could be to not permanently
    * run this thread, instead run when getUsed is called.
@@ -84,7 +84,7 @@ public class DU extends Shell {
           Thread.sleep(refreshInterval);
           
           try {
-            //update the used variable
+            //update the used VARRRRRRRRiable
             DU.this.run();
           } catch (IOException e) {
             synchronized (DU.this) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileContext.java
@@ -366,7 +366,7 @@ public final class FileContext {
    * construction. Changes to the config after the call are ignore
    * by the FileContext layer. 
    * The conf is passed to lower layers like AbstractFileSystem and HDFS which
-   * pick up their own config variables.
+   * pick up their own config VARRRRRRRRiables.
    */
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileStatus.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileStatus.java
@@ -85,7 +85,7 @@ public class FileStatus implements Writable, Comparable {
     this.group = (group == null) ? "" : group;
     this.symlink = symlink;
     this.path = path;
-    // The variables isdir and symlink indicate the type:
+    // The VARRRRRRRRiables isdir and symlink indicate the type:
     // 1. isdir implies directory, in which case symlink must be null.
     // 2. !isdir implies a file or symlink, symlink != null implies a
     //    symlink, otherwise it's a file.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -1991,7 +1991,7 @@ public abstract class FileSystem extends Configured implements Closeable {
     private final Map<Key, FileSystem> map = new HashMap<Key, FileSystem>();
     private final Set<Key> toAutoClose = new HashSet<Key>();
 
-    /** A variable that makes all objects in the cache unique */
+    /** A VARRRRRRRRiable that makes all objects in the cache unique */
     private static AtomicLong unique = new AtomicLong(1);
 
     FileSystem get(URI uri, Configuration conf) throws IOException{

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/HardLink.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/HardLink.java
@@ -61,7 +61,7 @@ public class HardLink {
     } else {
       // Unix
       getHardLinkCommand = new HardLinkCGUnix();
-      //override getLinkCountCommand for the particular Unix variant
+      //override getLinkCountCommand for the particular Unix VARRRRRRRRiant
       //Linux is already set as the default - {"stat","-c%h", null}
       if (osType == OSType.OS_TYPE_MAC) {
         String[] linkCountCmdTemplate = {"stat","-f%l", null};
@@ -105,7 +105,7 @@ public class HardLink {
    * needed functionality for creating hardlinks and querying link counts.
    * The particular implementation class is chosen during 
    * static initialization phase of the HardLink class.
-   * The "getter" methods construct shell command strings for various purposes.
+   * The "getter" methods construct shell command strings for VARRRRRRRRious purposes.
    */
   private static abstract class HardLinkCommandGetter {
 
@@ -173,7 +173,7 @@ public class HardLink {
     
     private static synchronized 
     void setLinkCountCmdTemplate(String[] template) {
-      //May update this for specific unix variants, 
+      //May update this for specific unix VARRRRRRRRiants, 
       //after static initialization phase
       getLinkCountCommand = template;
     }
@@ -257,7 +257,7 @@ public class HardLink {
    * 
    * Note that the linkCount shell command for Windows is actually
    * a Cygwin shell command, and depends on ${cygwin}/bin
-   * being in the Windows PATH environment variable, so
+   * being in the Windows PATH environment VARRRRRRRRiable, so
    * stat.exe can be found.
    */
   static class HardLinkCGWin extends HardLinkCommandGetter {
@@ -457,7 +457,7 @@ public class HardLink {
   }
 
   /*
-   * Implements {@link createHardLinkMult} with added variable  "maxLength",
+   * Implements {@link createHardLinkMult} with added VARRRRRRRRiable  "maxLength",
    * to ease unit testing of the auto-splitting feature for long lists.
    * Likewise why it returns "callCount", the number of sub-arrays that
    * the file list had to be split into.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/Options.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.util.Progressable;
 @InterfaceStability.Evolving
 public final class Options {
   /**
-   * Class to support the varargs for create() options.
+   * Class to support the VARRRRRRRRargs for create() options.
    *
    */
   public static class CreateOpts {
@@ -149,7 +149,7 @@ public final class Options {
       for (int i = 0; i < opts.length; ++i) {
         if (opts[i].getClass() == theClass) {
           if (result != null) 
-            throw new IllegalArgumentException("multiple blocksize varargs");
+            throw new IllegalArgumentException("multiple blocksize VARRRRRRRRargs");
           result = opts[i];
         }
       }
@@ -168,7 +168,7 @@ public final class Options {
         for (int i = 0; i < opts.length; ++i) {
           if (opts[i].getClass() == newValue.getClass()) {
             if (alreadyInOpts) 
-              throw new IllegalArgumentException("multiple opts varargs");
+              throw new IllegalArgumentException("multiple opts VARRRRRRRRargs");
             alreadyInOpts = true;
             opts[i] = newValue;
           }
@@ -186,7 +186,7 @@ public final class Options {
   }
 
   /**
-   * Enum to support the varargs for rename() options
+   * Enum to support the VARRRRRRRRargs for rename() options
    */
   public static enum Rename {
     NONE((byte) 0), // No options

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/kfs/KosmosFileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/kfs/KosmosFileSystem.java
@@ -290,7 +290,7 @@ public class KosmosFileSystem extends FileSystem {
 
     /**
      * Return null if the file doesn't exist; otherwise, get the
-     * locations of the various chunks of the file file from KFS.
+     * locations of the VARRRRRRRRious chunks of the file file from KFS.
      */
     @Override
     public BlockLocation[] getFileBlockLocations(FileStatus file, long start,

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Command.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/Command.java
@@ -162,7 +162,7 @@ abstract public class Command extends Configured {
   /**
    * The exit code to be returned if any errors occur during execution.
    * This method is needed to account for the inconsistency in the exit
-   * codes returned by various commands.
+   * codes returned by VARRRRRRRRious commands.
    * @return a non-zero exit code
    */
   protected int exitCodeForError() { return 1; }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/CommandFormat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/CommandFormat.java
@@ -65,7 +65,7 @@ public class CommandFormat {
   }
 
   /** Parse parameters starting from the given position
-   * Consider using the variant that directly takes a List
+   * Consider using the VARRRRRRRRiant that directly takes a List
    * 
    * @param args an array of input arguments
    * @param pos the position at which starts to parse

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ConfigUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ConfigUtil.java
@@ -22,21 +22,21 @@ import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 
 /**
- * Utilities for config variables of the viewFs See {@link ViewFs}
+ * Utilities for config VARRRRRRRRiables of the viewFs See {@link ViewFs}
  */
 public class ConfigUtil {
   /**
-   * Get the config variable prefix for the specified mount table
+   * Get the config VARRRRRRRRiable prefix for the specified mount table
    * @param mountTableName - the name of the mount table
-   * @return the config variable prefix for the specified mount table
+   * @return the config VARRRRRRRRiable prefix for the specified mount table
    */
   public static String getConfigViewFsPrefix(final String mountTableName) {
     return Constants.CONFIG_VIEWFS_PREFIX + "." + mountTableName;
   }
   
   /**
-   * Get the config variable prefix for the default mount table
-   * @return the config variable prefix for the default mount table
+   * Get the config VARRRRRRRRiable prefix for the default mount table
+   * @return the config VARRRRRRRRiable prefix for the default mount table
    */
   public static String getConfigViewFsPrefix() {
     return 
@@ -69,7 +69,7 @@ public class ConfigUtil {
   }
   
   /**
-   * Add config variable for homedir for default mount table
+   * Add config VARRRRRRRRiable for homedir for default mount table
    * @param conf - add to this conf
    * @param homedir - the home dir path starting with slash
    */
@@ -80,7 +80,7 @@ public class ConfigUtil {
   }
   
   /**
-   * Add config variable for homedir the specified mount table
+   * Add config VARRRRRRRRiable for homedir the specified mount table
    * @param conf - add to this conf
    * @param homedir - the home dir path starting with slash
    */
@@ -97,7 +97,7 @@ public class ConfigUtil {
   /**
    * Get the value of the home dir conf value for default mount table
    * @param conf - from this conf
-   * @return home dir value, null if variable is not in conf
+   * @return home dir value, null if VARRRRRRRRiable is not in conf
    */
   public static String getHomeDirValue(final Configuration conf) {
     return getHomeDirValue(conf, Constants.CONFIG_VIEWFS_DEFAULT_MOUNT_TABLE);
@@ -107,7 +107,7 @@ public class ConfigUtil {
    * Get the value of the home dir conf value for specfied mount table
    * @param conf - from this conf
    * @param mountTableName - the mount table
-   * @return home dir value, null if variable is not in conf
+   * @return home dir value, null if VARRRRRRRRiable is not in conf
    */
   public static String getHomeDirValue(final Configuration conf, 
       final String mountTableName) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/Constants.java
@@ -20,14 +20,14 @@ package org.apache.hadoop.fs.viewfs;
 import org.apache.hadoop.fs.permission.FsPermission;
 
 /**
- * Config variable prefixes for ViewFs -
+ * Config VARRRRRRRRiable prefixes for ViewFs -
  *     see {@link org.apache.hadoop.fs.viewfs.ViewFs} for examples.
  * The mount table is specified in the config using these prefixes.
  * See {@link org.apache.hadoop.fs.viewfs.ConfigUtil} for convenience lib.
  */
 public interface Constants {
   /**
-   * Prefix for the config variable prefix for the ViewFs mount-table
+   * Prefix for the config VARRRRRRRRiable prefix for the ViewFs mount-table
    */
   public static final String CONFIG_VIEWFS_PREFIX = "fs.viewfs.mounttable";
  
@@ -38,28 +38,28 @@ public interface Constants {
   public static final String CONFIG_VIEWFS_HOMEDIR = "homedir";
   
   /**
-   * Config variable name for the default mount table.
+   * Config VARRRRRRRRiable name for the default mount table.
    */
   public static final String CONFIG_VIEWFS_DEFAULT_MOUNT_TABLE = "default";
   
   /**
-   * Config variable full prefix for the default mount table.
+   * Config VARRRRRRRRiable full prefix for the default mount table.
    */
   public static final String CONFIG_VIEWFS_PREFIX_DEFAULT_MOUNT_TABLE = 
           CONFIG_VIEWFS_PREFIX + "." + CONFIG_VIEWFS_DEFAULT_MOUNT_TABLE;
   
   /**
-   * Config variable for specifying a simple link
+   * Config VARRRRRRRRiable for specifying a simple link
    */
   public static final String CONFIG_VIEWFS_LINK = "link";
   
   /**
-   * Config variable for specifying a merge link
+   * Config VARRRRRRRRiable for specifying a merge link
    */
   public static final String CONFIG_VIEWFS_LINK_MERGE = "linkMerge";
   
   /**
-   * Config variable for specifying a merge of the root of the mount-table
+   * Config VARRRRRRRRiable for specifying a merge of the root of the mount-table
    *  with the root of another file system. 
    */
   public static final String CONFIG_VIEWFS_LINK_MERGE_SLASH = "linkMergeSlash";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/InodeTree.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.util.StringUtils;
  * In order to use it the caller must subclass it and implement
  * the abstract methods {@link #getTargetFileSystem(INodeDir)}, etc.
  * 
- * The mountable is initialized from the config variables as 
+ * The mountable is initialized from the config VARRRRRRRRiables as 
  * specified in {@link ViewFs}
  *
  * @param <T> is AbstractFileSystem or FileSystem

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/viewfs/ViewFs.java
@@ -75,23 +75,23 @@ import org.apache.hadoop.util.Progressable;
  * <p>
  * To use viewfs one would typically set the default file system in the
  * config  (i.e. fs.default.name< = viewfs:///) along with the
- * mount table config variables as described below. 
+ * mount table config VARRRRRRRRiables as described below. 
  * 
  * <p>
- * <b> ** Config variables to specify the mount table entries ** </b>
+ * <b> ** Config VARRRRRRRRiables to specify the mount table entries ** </b>
  * <p>
  * 
  * The file system is initialized from the standard Hadoop config through
- * config variables.
+ * config VARRRRRRRRiables.
  * See {@link FsConstants} for URI and Scheme constants; 
- * See {@link Constants} for config var constants; 
+ * See {@link Constants} for config VARRRRRRRR constants; 
  * see {@link ConfigUtil} for convenient lib.
  * 
  * <p>
  * All the mount table config entries for view fs are prefixed by 
  * <b>fs.viewfs.mounttable.</b>
  * For example the above example can be specified with the following
- *  config variables:
+ *  config VARRRRRRRRiables:
  *  <ul>
  *  <li> fs.viewfs.mounttable.default.link./user=
  *  hdfs://nnContainingUserDir/user
@@ -104,13 +104,13 @@ import org.apache.hadoop.util.Progressable;
  *  </ul>
  *  
  * The default mount table (when no authority is specified) is 
- * from config variables prefixed by <b>fs.viewFs.mounttable.default </b>
+ * from config VARRRRRRRRiables prefixed by <b>fs.viewFs.mounttable.default </b>
  * The authority component of a URI can be used to specify a different mount
  * table. For example,
  * <ul>
  * <li>  viewfs://sanjayMountable/
  * </ul>
- * is initialized from fs.viewFs.mounttable.sanjayMountable.* config variables.
+ * is initialized from fs.viewFs.mounttable.sanjayMountable.* config VARRRRRRRRiables.
  * 
  *  <p> 
  *  <b> **** Merge Mounts **** </b>(NOTE: merge mounts are not implemented yet.)
@@ -124,7 +124,7 @@ import org.apache.hadoop.util.Progressable;
  *   <ul>
  *   <li> /user -> hdfs://nnUser1/user,hdfs://nnUser2/user
  *   </ul>
- *  Such a mergeLink can be specified with the following config var where ","
+ *  Such a mergeLink can be specified with the following config VARRRRRRRR where ","
  *  is used as the separator for each of links to be merged:
  *  <ul>
  *  <li> fs.viewfs.mounttable.default.linkMerge./user=

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/VIntWritable.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/VIntWritable.java
@@ -23,7 +23,7 @@ import java.io.*;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
-/** A WritableComparable for integer values stored in variable-length format.
+/** A WritableComparable for integer values stored in VARRRRRRRRiable-length format.
  * Such values take between one and five bytes.  Smaller values take fewer bytes.
  * 
  * @see org.apache.hadoop.io.WritableUtils#readVInt(DataInput)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/VLongWritable.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/VLongWritable.java
@@ -23,7 +23,7 @@ import java.io.*;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
-/** A WritableComparable for longs in a variable-length format. Such values take
+/** A WritableComparable for longs in a VARRRRRRRRiable-length format. Such values take
  *  between one and five bytes.  Smaller values take fewer bytes.
  *  
  *  @see org.apache.hadoop.io.WritableUtils#readVLong(DataInput)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableUtils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/WritableUtils.java
@@ -353,7 +353,7 @@ public final class WritableUtils  {
   }
 
   /**
-   * Get the encoded length if an integer is stored in a variable-length format
+   * Get the encoded length if an integer is stored in a VARRRRRRRRiable-length format
    * @return the encoded length 
    */
   public static int getVIntSize(long i) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/Decompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/Decompressor.java
@@ -36,7 +36,7 @@ public interface Decompressor {
    * Sets input data for decompression. 
    * This should be called if and only if {@link #needsInput()} returns 
    * <code>true</code> indicating that more input data is required.
-   * (Both native and non-native versions of various Decompressors require
+   * (Both native and non-native versions of VARRRRRRRRious Decompressors require
    * that the data passed in via <code>b[]</code> remain unmodified until
    * the caller is explicitly notified--via {@link #needsInput()}--that the
    * buffer may be safely modified.  With this requirement, an extra

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/bzip2/CBZip2InputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/bzip2/CBZip2InputStream.java
@@ -80,9 +80,9 @@ public class CBZip2InputStream extends InputStream implements BZip2Constants {
   public static final long EOS_DELIMITER = 0X177245385090L;// end of bzip2 stream
   private static final int DELIMITER_BIT_LENGTH = 48;
   READ_MODE readMode = READ_MODE.CONTINUOUS;
-  // The variable records the current advertised position of the stream.
+  // The VARRRRRRRRiable records the current advertised position of the stream.
   private long reportedBytesReadFromCompressedStream = 0L;
-  // The following variable keep record of compressed bytes read.
+  // The following VARRRRRRRRiable keep record of compressed bytes read.
   private long bytesReadFromCompressedStream = 0L;
   private boolean lazyInitialization = false;
   private byte array[] = new byte[1];

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/bzip2/CBZip2OutputStream.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/bzip2/CBZip2OutputStream.java
@@ -1746,7 +1746,7 @@ public class CBZip2OutputStream extends OutputStream implements BZip2Constants {
     }
 
     /*
-    * In the various block-sized structures, live data runs from 0 to
+    * In the VARRRRRRRRious block-sized structures, live data runs from 0 to
     * last+NUM_OVERSHOOT_BYTES inclusive. First, set up the overshoot area
     * for block.
     */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/snappy/SnappyDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/snappy/SnappyDecompressor.java
@@ -87,7 +87,7 @@ public class SnappyDecompressor implements Decompressor {
    * Sets input data for decompression.
    * This should be called if and only if {@link #needsInput()} returns
    * <code>true</code> indicating that more input data is required.
-   * (Both native and non-native versions of various Decompressors require
+   * (Both native and non-native versions of VARRRRRRRRious Decompressors require
    * that the data passed in via <code>b[]</code> remain unmodified until
    * the caller is explicitly notified--via {@link #needsInput()}--that the
    * buffer may be safely modified.  With this requirement, an extra

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipDecompressor.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/zlib/BuiltInGzipDecompressor.java
@@ -64,7 +64,7 @@ public class BuiltInGzipDecompressor implements Decompressor {
 
   /**
    * The current state of the gzip decoder, external to the Inflater context.
-   * (Technically, the private variables localBuf through hasHeaderCRC are
+   * (Technically, the private VARRRRRRRRiables localBuf through hasHeaderCRC are
    * also part of the state, so this enum is merely the label for it.)
    */
   private static enum GzipStateLabel {
@@ -213,7 +213,7 @@ public class BuiltInGzipDecompressor implements Decompressor {
           "logic error: Inflater finished; byte-count is inconsistent";
           // could save a copy of userBufLen at call to inflater.setInput() and
           // verify that bytesRemaining <= origUserBufLen, but would have to
-          // be a (class) member variable...seems excessive for a sanity check
+          // be a (class) member VARRRRRRRRiable...seems excessive for a sanity check
         userBufOff -= bytesRemaining;
         userBufLen = bytesRemaining;   // or "+=", but guaranteed 0 coming in
       } else {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/file/tfile/TFile.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/file/tfile/TFile.java
@@ -83,7 +83,7 @@ import org.apache.hadoop.io.serializer.JavaSerializationComparator;
  * can be estimated as (40+AvgMetaBlockName)*NumMetaBlock.
  * </ul>
  * <p>
- * The behavior of TFile can be customized by the following variables through
+ * The behavior of TFile can be customized by the following VARRRRRRRRiables through
  * Configuration:
  * <ul>
  * <li><b>tfile.io.chunk.size</b>: Value chunk size. Integer (in bytes). Default

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/file/tfile/Utils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/file/tfile/Utils.java
@@ -42,7 +42,7 @@ public final class Utils {
   }
 
   /**
-   * Encoding an integer into a variable-length encoding format. Synonymous to
+   * Encoding an integer into a VARRRRRRRRiable-length encoding format. Synonymous to
    * <code>Utils#writeVLong(out, n)</code>.
    * 
    * @param out
@@ -57,7 +57,7 @@ public final class Utils {
   }
 
   /**
-   * Encoding a Long integer into a variable-length encoding format.
+   * Encoding a Long integer into a VARRRRRRRRiable-length encoding format.
    * <ul>
    * <li>if n in [-32, 127): encode in one byte with the actual value.
    * Otherwise,
@@ -158,7 +158,7 @@ public final class Utils {
   }
 
   /**
-   * Decoding the variable-length integer. Synonymous to
+   * Decoding the VARRRRRRRRiable-length integer. Synonymous to
    * <code>(int)Utils#readVLong(in)</code>.
    * 
    * @param in
@@ -178,7 +178,7 @@ public final class Utils {
   }
 
   /**
-   * Decoding the variable-length integer. Suppose the value of the first byte
+   * Decoding the VARRRRRRRRiable-length integer. Suppose the value of the first byte
    * is FB, and the following bytes are NB[*].
    * <ul>
    * <li>if (FB >= -32), return (long)FB;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/nativeio/NativeIO.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.util.NativeCodeLoader;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 /**
- * JNI wrappers for various native IO-related calls not available in Java.
+ * JNI wrappers for VARRRRRRRRious native IO-related calls not available in Java.
  * These functions should generally be used alongside a fallback to another
  * more portable mechanism.
  */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/metrics/RpcMetrics.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 
 /**
- * This class is for maintaining  the various RPC statistics
+ * This class is for maintaining  the VARRRRRRRRious RPC statistics
  * and publishing them through the metrics interfaces.
  */
 @InterfaceAudience.Private

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsIntValue.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsIntValue.java
@@ -25,7 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * The MetricsIntValue class is for a metric that is not time varied
+ * The MetricsIntValue class is for a metric that is not time VARRRRRRRRied
  * but changes only when it is set. 
  * Each time its value is set, it is published only *once* at the next update
  * call.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsLongValue.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsLongValue.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.metrics.MetricsRecord;
 
 
 /**
- * The MetricsLongValue class is for a metric that is not time varied
+ * The MetricsLongValue class is for a metric that is not time VARRRRRRRRied
  * but changes only when it is set. 
  * Each time its value is set, it is published only *once* at the next update
  * call.

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsTimeVaryingInt.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsTimeVaryingInt.java
@@ -26,7 +26,7 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * The MetricsTimeVaryingInt class is for a metric that naturally
- * varies over time (e.g. number of files created). The metrics is accumulated
+ * VARRRRRRRRies over time (e.g. number of files created). The metrics is accumulated
  * over an interval (set in the metrics config file); the metrics is
  *  published at the end of each interval and then 
  * reset to zero. Hence the counter has the value in the current interval. 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsTimeVaryingLong.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsTimeVaryingLong.java
@@ -27,7 +27,7 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * The MetricsTimeVaryingLong class is for a metric that naturally
- * varies over time (e.g. number of files created). The metrics is accumulated
+ * VARRRRRRRRies over time (e.g. number of files created). The metrics is accumulated
  * over an interval (set in the metrics config file); the metrics is
  *  published at the end of each interval and then 
  * reset to zero. Hence the counter has the value in the current interval. 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsTimeVaryingRate.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics/util/MetricsTimeVaryingRate.java
@@ -26,7 +26,7 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * The MetricsTimeVaryingRate class is for a rate based metric that
- * naturally varies over time (e.g. time taken to create a file).
+ * naturally VARRRRRRRRies over time (e.g. time taken to create a file).
  * The rate is averaged at each interval heart beat (the interval
  * is set in the metrics config file).
  * This class also keeps track of the min and max rates along with 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/MetricType.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/MetricType.java
@@ -25,7 +25,7 @@ public enum MetricType {
   COUNTER,
 
   /**
-   * An arbitrary varying metric
+   * An arbitrary VARRRRRRRRying metric
    */
   GAUGE
 }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSystemImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MetricsSystemImpl.java
@@ -560,7 +560,7 @@ public class MetricsSystemImpl extends MetricsSystem implements MetricsSource {
 
   private InitMode initMode() {
     LOG.debug("from system property: "+ System.getProperty(MS_INIT_MODE_KEY));
-    LOG.debug("from environment variable: "+ System.getenv(MS_INIT_MODE_KEY));
+    LOG.debug("from environment VARRRRRRRRiable: "+ System.getenv(MS_INIT_MODE_KEY));
     String m = System.getProperty(MS_INIT_MODE_KEY);
     String m2 = m == null ? System.getenv(MS_INIT_MODE_KEY) : m;
     return InitMode.valueOf((m2 == null ? InitMode.NORMAL.name() : m2)

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/package-info.java
@@ -31,7 +31,7 @@
     and publication.
   </p>
 
-  <p>The framework provides a variety of ways to implement metrics
+  <p>The framework provides a VARRRRRRRRiety of ways to implement metrics
     instrumentation easily via the simple
     {@link org.apache.hadoop.metrics2.MetricsSource} interface
     or the even simpler and more concise and declarative metrics annotations.
@@ -138,7 +138,7 @@
     <dd>The {@link org.apache.hadoop.metrics2.annotation.Metric} annotation
       identifies a particular metric, which in this case, is the
       result of the method call getMyMetric of the "gauge" (default) type,
-      which means it can vary in both directions, compared with a "counter"
+      which means it can VARRRRRRRRy in both directions, compared with a "counter"
       type, which can only increase or stay the same. The name of the metric
       is "MyMetric" (inferred from getMyMetric method name by default.) The 42
       here is the value of the metric which can be substituted with any valid

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/sink/ganglia/AbstractGangliaSink.java
@@ -96,7 +96,7 @@ public abstract class AbstractGangliaSink implements MetricsSink {
   };
 
   /**
-   * define enum for various type of conf
+   * define enum for VARRRRRRRRious type of conf
    */
   public enum GangliaConfType {
     slope, units, dmax, tmax

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetrics.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetrics.java
@@ -44,7 +44,7 @@ import static org.apache.hadoop.metrics2.impl.MsInfo.*;
 
 /**
  * JVM and logging related metrics.
- * Mostly used by various servers as a part of the metrics they export.
+ * Mostly used by VARRRRRRRRious servers as a part of the metrics they export.
  */
 @InterfaceAudience.Private
 public class JvmMetrics implements MetricsSource {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleStat.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/SampleStat.java
@@ -110,9 +110,9 @@ public class SampleStat {
   }
 
   /**
-   * @return  the variance of the samples
+   * @return  the VARRRRRRRRiance of the samples
    */
-  public double variance() {
+  public double VARRRRRRRRiance() {
     return numSamples > 1 ? s1 / (numSamples - 1) : 0.0;
   }
 
@@ -120,7 +120,7 @@ public class SampleStat {
    * @return  the standard deviation of the samples
    */
   public double stddev() {
-    return Math.sqrt(variance());
+    return Math.sqrt(VARRRRRRRRiance());
   }
 
   /**

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/Utils.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/Utils.java
@@ -453,7 +453,7 @@ public class Utils {
   }
   
   /**
-   * Get the encoded length if an integer is stored in a variable-length format
+   * Get the encoded length if an integer is stored in a VARRRRRRRRiable-length format
    * @return the encoded length
    */
   public static int getVIntSize(long i) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/Consts.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/Consts.java
@@ -39,9 +39,9 @@ public class Consts {
   private Consts() {
   }
   
-  // prefix to use for variables in generated classes
+  // prefix to use for VARRRRRRRRiables in generated classes
   public static final String RIO_PREFIX = "_rio_";
-  // other vars used in generated classes
+  // other VARRRRRRRRs used in generated classes
   public static final String RTI_VAR = RIO_PREFIX + "recTypeInfo";
   public static final String RTI_FILTER = RIO_PREFIX + "rtiFilter";
   public static final String RTI_FILTER_FIELDS = RIO_PREFIX + "rtiFilterFields";

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/JRecord.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/JRecord.java
@@ -257,7 +257,7 @@ public class JRecord extends JCompType {
       // setupRtiFields()
       genSetupRtiFields(cb);
 
-      // getters/setters for member variables
+      // getters/setters for member VARRRRRRRRiables
       for (Iterator<JField<JavaType>> i = fields.iterator(); i.hasNext();) {
         JField<JavaType> jf = i.next();
         String name = jf.getName();
@@ -556,7 +556,7 @@ public class JRecord extends JCompType {
         type.genDecl(hb, name);
       }
       
-      // type info vars
+      // type info VARRRRRRRRs
       hb.append("static ::hadoop::RecordTypeInfo* p" + Consts.RTI_VAR + ";\n");
       hb.append("static ::hadoop::RecordTypeInfo* p" + Consts.RTI_FILTER + ";\n");
       hb.append("static int* p" + Consts.RTI_FILTER_FIELDS + ";\n");
@@ -593,7 +593,7 @@ public class JRecord extends JCompType {
       
       CodeBuffer cb = new CodeBuffer();
 
-      // initialize type info vars
+      // initialize type info VARRRRRRRRs
       cb.append("::hadoop::RecordTypeInfo* " + fullName + "::p" + 
           Consts.RTI_VAR + " = " + fullName + "::setupTypeInfo();\n");
       cb.append("::hadoop::RecordTypeInfo* " + fullName + "::p" + 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/JType.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/JType.java
@@ -85,8 +85,8 @@ abstract public class JType {
       cb.append("}\n");
     }
 
-    void genRtiNestedFieldCondition(CodeBuffer cb, String varName, int ct) {
-      cb.append("if (" + varName + ".getElementTypeID().getTypeVal() == " +
+    void genRtiNestedFieldCondition(CodeBuffer cb, String VARRRRRRRRName, int ct) {
+      cb.append("if (" + VARRRRRRRRName + ".getElementTypeID().getTypeVal() == " +
           "org.apache.hadoop.record.meta." + getTypeIDByteString() + 
           ") {\n");
       cb.append("rtiFilterFields[i] = " + ct + ";\n");

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/generated/ParseException.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/generated/ParseException.java
@@ -83,7 +83,7 @@ public class ParseException extends Exception {
   }
 
   /**
-   * This variable determines which constructor was used to create
+   * This VARRRRRRRRiable determines which constructor was used to create
    * this object and thereby affects the semantics of the
    * "getMessage" method (see below).
    */

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/generated/Token.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/generated/Token.java
@@ -93,7 +93,7 @@ public class Token {
    *    case MyParserConstants.ID : return new IDToken();
    *
    * to the following switch statement. Then you can cast matchedToken
-   * variable to the appropriate type and use it in your lexical actions.
+   * VARRRRRRRRiable to the appropriate type and use it in your lexical actions.
    */
   public static final Token newToken(int ofKind)
   {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/generated/TokenMgrError.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/record/compiler/generated/TokenMgrError.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 public class TokenMgrError extends Error
 {
   /*
-   * Ordinals for various reasons why an Error of this type can be thrown.
+   * Ordinals for VARRRRRRRRious reasons why an Error of this type can be thrown.
    */
 
   /**
@@ -143,7 +143,7 @@ public class TokenMgrError extends Error
   }
 
   /*
-   * Constructors of various flavors follow.
+   * Constructors of VARRRRRRRRious flavors follow.
    */
 
   public TokenMgrError() {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/GroupMappingServiceProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/GroupMappingServiceProvider.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 public interface GroupMappingServiceProvider {
   
   /**
-   * Get all various group memberships of a given user.
+   * Get all VARRRRRRRRious group memberships of a given user.
    * Returns EMPTY list in case of non-existing user
    * @param user User's name
    * @return group memberships of user

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/Groups.java
@@ -34,7 +34,7 @@ import org.apache.commons.logging.LogFactory;
 /**
  * A user-to-groups mapping service.
  * 
- * {@link Groups} allows for server to get the various group memberships
+ * {@link Groups} allows for server to get the VARRRRRRRRious group memberships
  * of a given user via the {@link #getGroups(String)} call, thus ensuring 
  * a consistent user-to-groups mapping and protects against vagaries of 
  * different mappings on servers and clients in a Hadoop cluster. 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java
@@ -178,7 +178,7 @@ public class UserGroupInformation {
 
   /** Metrics to track UGI activity */
   static UgiMetrics metrics = UgiMetrics.create();
-  /** Are the static variables that depend on configuration initialized? */
+  /** Are the static VARRRRRRRRiables that depend on configuration initialized? */
   private static boolean isInitialized = false;
   /** Should we use Kerberos configuration? */
   private static boolean useKerberos;
@@ -191,7 +191,7 @@ public class UserGroupInformation {
   /** Leave 10 minutes between relogin attempts. */
   private static final long MIN_TIME_BEFORE_RELOGIN = 10 * 60 * 1000L;
   
-  /**Environment variable pointing to the token cache file*/
+  /**Environment VARRRRRRRRiable pointing to the token cache file*/
   public static final String HADOOP_TOKEN_FILE_LOCATION = 
     "HADOOP_TOKEN_FILE_LOCATION";
   

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Options.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Options.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 
 /**
- * This class allows generic access to variable length type-safe parameter
+ * This class allows generic access to VARRRRRRRRiable length type-safe parameter
  * lists.
  */
 public class Options {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ProtoUtil.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ProtoUtil.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 public abstract class ProtoUtil {
 
   /**
-   * Read a variable length integer in the same format that ProtoBufs encodes.
+   * Read a VARRRRRRRRiable length integer in the same format that ProtoBufs encodes.
    * @param in the input stream to read from
    * @return the integer
    * @throws IOException if it is malformed or EOF.
@@ -55,7 +55,7 @@ public abstract class ProtoUtil {
                 return result;
               }
             }
-            throw new IOException("Malformed varint");
+            throw new IOException("Malformed VARRRRRRRRint");
           }
         }
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Shell.java
@@ -167,7 +167,7 @@ abstract public class Shell {
   }
   
   /** set the environment for the command 
-   * @param env Mapping of environment variables
+   * @param env Mapping of environment VARRRRRRRRiables
    */
   protected void setEnvironment(Map<String, String> env) {
     this.environment = env;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Tool.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/Tool.java
@@ -46,7 +46,7 @@ import org.apache.hadoop.conf.Configurable;
  *         Path in = new Path(args[1]);
  *         Path out = new Path(args[2]);
  *         
- *         // Specify various job-specific parameters     
+ *         // Specify VARRRRRRRRious job-specific parameters     
  *         job.setJobName("my-app");
  *         job.setInputPath(in);
  *         job.setOutputPath(out);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/BloomFilter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/BloomFilter.java
@@ -66,7 +66,7 @@ import org.apache.hadoop.classification.InterfaceStability;
  * offers for the transmission of set membership information between networked hosts.  A sender encodes 
  * the information into a bit vector, the Bloom filter, that is more compact than a conventional 
  * representation. Computation and space costs for construction are linear in the number of elements.  
- * The receiver uses the filter to test whether various elements are members of the set. Though the 
+ * The receiver uses the filter to test whether VARRRRRRRRious elements are members of the set. Though the 
  * filter will occasionally return a false positive, it will never return a false negative. When creating 
  * the filter, the sender can choose its desired point in a trade-off between the false positive rate and the size. 
  * 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/CountingBloomFilter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/CountingBloomFilter.java
@@ -129,7 +129,7 @@ public final class CountingBloomFilter extends Filter {
   /**
    * Removes a specified key from <i>this</i> counting Bloom filter.
    * <p>
-   * <b>Invariant</b>: nothing happens if the specified key does not belong to <i>this</i> counter Bloom filter.
+   * <b>InVARRRRRRRRiant</b>: nothing happens if the specified key does not belong to <i>this</i> counter Bloom filter.
    * @param key The key to remove.
    */
   public void delete(Key key) {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/Filter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/Filter.java
@@ -123,7 +123,7 @@ public abstract class Filter implements Writable {
   /**
    * Peforms a logical AND between <i>this</i> filter and a specified filter.
    * <p>
-   * <b>Invariant</b>: The result is assigned to <i>this</i> filter.
+   * <b>InVARRRRRRRRiant</b>: The result is assigned to <i>this</i> filter.
    * @param filter The filter to AND with.
    */
   public abstract void and(Filter filter);
@@ -131,7 +131,7 @@ public abstract class Filter implements Writable {
   /**
    * Peforms a logical OR between <i>this</i> filter and a specified filter.
    * <p>
-   * <b>Invariant</b>: The result is assigned to <i>this</i> filter.
+   * <b>InVARRRRRRRRiant</b>: The result is assigned to <i>this</i> filter.
    * @param filter The filter to OR with.
    */
   public abstract void or(Filter filter);
@@ -139,7 +139,7 @@ public abstract class Filter implements Writable {
   /**
    * Peforms a logical XOR between <i>this</i> filter and a specified filter.
    * <p>
-   * <b>Invariant</b>: The result is assigned to <i>this</i> filter.
+   * <b>InVARRRRRRRRiant</b>: The result is assigned to <i>this</i> filter.
    * @param filter The filter to XOR with.
    */
   public abstract void xor(Filter filter);

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/Key.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/Key.java
@@ -70,7 +70,7 @@ public class Key implements WritableComparable<Key> {
   /**
    * The weight associated to <i>this</i> key.
    * <p>
-   * <b>Invariant</b>: if it is not specified, each instance of 
+   * <b>InVARRRRRRRRiant</b>: if it is not specified, each instance of 
    * <code>Key</code> will have a default weight of 1.0
    */
   double weight;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/RetouchedBloomFilter.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/bloom/RetouchedBloomFilter.java
@@ -133,7 +133,7 @@ implements RemoveScheme {
   /**
    * Adds a false positive information to <i>this</i> retouched Bloom filter.
    * <p>
-   * <b>Invariant</b>: if the false positive is <code>null</code>, nothing happens.
+   * <b>InVARRRRRRRRiant</b>: if the false positive is <code>null</code>, nothing happens.
    * @param key The false positive key to add.
    */
   public void addFalsePositive(Key key) {
@@ -387,7 +387,7 @@ implements RemoveScheme {
   }
   
   /**
-   * Creates and initialises the various vectors.
+   * Creates and initialises the VARRRRRRRRious vectors.
    */
   @SuppressWarnings("unchecked")
   private void createVector() {

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/hash/JenkinsHash.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/hash/JenkinsHash.java
@@ -57,9 +57,9 @@ public class JenkinsHash extends Hash {
   }
 
   /**
-   * taken from  hashlittle() -- hash a variable-length key into a 32-bit value
+   * taken from  hashlittle() -- hash a VARRRRRRRRiable-length key into a 32-bit value
    * 
-   * @param key the key (the unaligned variable-length array of bytes)
+   * @param key the key (the unaligned VARRRRRRRRiable-length array of bytes)
    * @param nbytes number of bytes to include in hash
    * @param initval can be any integer value
    * @return a 32-bit value.  Every bit of the key affects every bit of the
@@ -129,7 +129,7 @@ public class JenkinsHash extends Hash {
        * Well, "9 15 3 18 27 15" didn't quite get 32 bits diffing for 
        * "differ" defined as + with a one-bit base and a two-bit delta.  I
        * used http://burtleburtle.net/bob/hash/avalanche.html to choose
-       * the operations, constants, and arrangements of the variables.
+       * the operations, constants, and arrangements of the VARRRRRRRRiables.
        * 
        * This does not achieve avalanche.  There are input bits of (a,b,c)
        * that fail to affect some output bits of (a,b,c), especially of a.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/conf/TestConfiguration.java
@@ -74,15 +74,15 @@ public class TestConfiguration extends TestCase {
   public void testVariableSubstitution() throws IOException {
     out=new BufferedWriter(new FileWriter(CONFIG));
     startConfig();
-    declareProperty("my.int", "${intvar}", "42");
-    declareProperty("intvar", "42", "42");
+    declareProperty("my.int", "${intVARRRRRRRR}", "42");
+    declareProperty("intVARRRRRRRR", "42", "42");
     declareProperty("my.base", "/tmp/${user.name}", UNSPEC);
     declareProperty("my.file", "hello", "hello");
     declareProperty("my.suffix", ".txt", ".txt");
     declareProperty("my.relfile", "${my.file}${my.suffix}", "hello.txt");
     declareProperty("my.fullfile", "${my.base}/${my.file}${my.suffix}", UNSPEC);
-    // check that undefined variables are returned as-is
-    declareProperty("my.failsexpand", "a${my.undefvar}b", "a${my.undefvar}b");
+    // check that undefined VARRRRRRRRiables are returned as-is
+    declareProperty("my.failsexpand", "a${my.undefVARRRRRRRR}b", "a${my.undefVARRRRRRRR}b");
     endConfig();
     Path fileResource = new Path(CONFIG);
     conf.addResource(fileResource);
@@ -94,7 +94,7 @@ public class TestConfiguration extends TestCase {
       assertEq(p.val, gotRawVal);
       if (p.expectEval == UNSPEC) {
         // expansion is system-dependent (uses System properties)
-        // can't do exact match so just check that all variables got expanded
+        // can't do exact match so just check that all VARRRRRRRRiables got expanded
         assertTrue(gotVal != null && -1 == gotVal.indexOf("${"));
       } else {
         assertEq(p.expectEval, gotVal);
@@ -102,29 +102,29 @@ public class TestConfiguration extends TestCase {
     }
       
     // check that expansion also occurs for getInt()
-    assertTrue(conf.getInt("intvar", -1) == 42);
+    assertTrue(conf.getInt("intVARRRRRRRR", -1) == 42);
     assertTrue(conf.getInt("my.int", -1) == 42);
   }
 
   public void testFinalParam() throws IOException {
     out=new BufferedWriter(new FileWriter(CONFIG));
     startConfig();
-    declareProperty("my.var", "", "", true);
+    declareProperty("my.VARRRRRRRR", "", "", true);
     endConfig();
     Path fileResource = new Path(CONFIG);
     Configuration conf1 = new Configuration();
     conf1.addResource(fileResource);
-    assertNull("my var is not null", conf1.get("my.var"));
+    assertNull("my VARRRRRRRR is not null", conf1.get("my.VARRRRRRRR"));
 	
     out=new BufferedWriter(new FileWriter(CONFIG2));
     startConfig();
-    declareProperty("my.var", "myval", "myval", false);
+    declareProperty("my.VARRRRRRRR", "myval", "myval", false);
     endConfig();
     fileResource = new Path(CONFIG2);
 
     Configuration conf2 = new Configuration(conf1);
     conf2.addResource(fileResource);
-    assertNull("my var is not final", conf2.get("my.var"));
+    assertNull("my VARRRRRRRR is not final", conf2.get("my.VARRRRRRRR"));
   }
 
   public static void assertEq(Object a, Object b) {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FSMainOperationsBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FSMainOperationsBaseTest.java
@@ -46,7 +46,7 @@ import static org.apache.hadoop.fs.FileSystemTestHelper.*;
  * <p>
  * To test a given {@link FileSystem} implementation create a subclass of this
  * test and override {@link #setUp()} to initialize the <code>fSys</code> 
- * {@link FileSystem} instance variable.
+ * {@link FileSystem} instance VARRRRRRRRiable.
  * 
  * Since this a junit 4 you can also do a single setup before 
  * the start of any tests.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextCreateMkdirBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextCreateMkdirBaseTest.java
@@ -39,7 +39,7 @@ import org.apache.commons.logging.impl.Log4JLogger;
  * <p>
  * To test a given {@link FileSystem} implementation create a subclass of this
  * test and override {@link #setUp()} to initialize the <code>fc</code> 
- * {@link FileContext} instance variable.
+ * {@link FileContext} instance VARRRRRRRRiable.
  * 
  * Since this a junit 4 you can also do a single setup before 
  * the start of any tests.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextMainOperationsBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextMainOperationsBaseTest.java
@@ -44,7 +44,7 @@ import static org.apache.hadoop.fs.CreateFlag.*;
  * <p>
  * To test a given {@link FileSystem} implementation create a subclass of this
  * test and override {@link #setUp()} to initialize the <code>fc</code> 
- * {@link FileContext} instance variable.
+ * {@link FileContext} instance VARRRRRRRRiable.
  * 
  * Since this a junit 4 you can also do a single setup before 
  * the start of any tests.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextPermissionBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextPermissionBase.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertEquals;
  * <p>
  * To test a given {@link FileSystem} implementation create a subclass of this
  * test and override {@link #setUp()} to initialize the <code>fc</code> 
- * {@link FileContext} instance variable.
+ * {@link FileContext} instance VARRRRRRRRiable.
  * 
  * Since this a junit 4 you can also do a single setup before 
  * the start of any tests.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextURIBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextURIBase.java
@@ -47,7 +47,7 @@ import static org.apache.hadoop.fs.FileContextTestHelper.*;
  * 
  * The tests will do operations on fc1 that use a URI in fc2
  * 
- * {@link FileContext} instance variable.
+ * {@link FileContext} instance VARRRRRRRRiable.
  * </p>
  */
 public abstract class FileContextURIBase {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextUtilBase.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileContextUtilBase.java
@@ -39,7 +39,7 @@ import org.junit.Test;
  * <p>
  * To test a given {@link FileSystem} implementation create a subclass of this
  * test and override {@link #setUp()} to initialize the <code>fc</code> 
- * {@link FileContext} instance variable.
+ * {@link FileContext} instance VARRRRRRRRiable.
  * 
  * </p>
  */

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemContractBaseTest.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/FileSystemContractBaseTest.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.fs.Path;
  * <p>
  * To test a given {@link FileSystem} implementation create a subclass of this
  * test and override {@link #setUp()} to initialize the <code>fs</code> 
- * {@link FileSystem} instance variable.
+ * {@link FileSystem} instance VARRRRRRRRiable.
  * </p>
  */
 public abstract class FileSystemContractBaseTest extends TestCase {

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestCommandFormat.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestCommandFormat.java
@@ -199,7 +199,7 @@ public class TestCommandFormat {
   }
   
   // Don't use generics to avoid warning:
-  // unchecked generic array creation of type T[] for varargs parameter
+  // unchecked generic array creation of type T[] for VARRRRRRRRargs parameter
   private static List<String> listOf(String ... objects) {
     return Arrays.asList(objects);
   }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHardLink.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestHardLink.java
@@ -64,7 +64,7 @@ import static org.apache.hadoop.fs.HardLink.*;
  * in fact have admin privs).
  * (b) The getLinkCount() test case will fail for Windows, unless Cygwin
  * is set up properly.  In particular, ${cygwin}/bin must be in
- * the PATH environment variable, so the cygwin utilities can be found.
+ * the PATH environment VARRRRRRRRiable, so the cygwin utilities can be found.
  */
 public class TestHardLink {
   

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestPathData.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/shell/TestPathData.java
@@ -66,7 +66,7 @@ public class TestPathData {
     item = new PathData(dirString, conf);
     checkPathData();
 
-    // properly implementing symlink support in various commands will require
+    // properly implementing symlink support in VARRRRRRRRious commands will require
     // trailing slashes to be retained
     dirString = "d1/";
     item = new PathData(dirString, conf);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSeqFileComparison.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileSeqFileComparison.java
@@ -508,7 +508,7 @@ public class TestTFileSeqFileComparison extends TestCase {
     int minBlockSize = 256 * 1024;
     int fsOutputBufferSize = 1;
     int fsInputBufferSize = 0;
-    // special variable only for unit testing.
+    // special VARRRRRRRRiable only for unit testing.
     int fsInputBufferSizeNone = 0;
     int fsInputBufferSizeGz = 0;
     int fsInputBufferSizeLzo = 0;
@@ -586,7 +586,7 @@ public class TestTFileSeqFileComparison extends TestCase {
               .withArgName("length")
               .hasArg()
               .withDescription(
-                  "base length of the key (in bytes), actual length varies in [base, 2*base)")
+                  "base length of the key (in bytes), actual length VARRRRRRRRies in [base, 2*base)")
               .create('k');
 
       Option valueLen =
@@ -595,7 +595,7 @@ public class TestTFileSeqFileComparison extends TestCase {
               .withArgName("length")
               .hasArg()
               .withDescription(
-                  "base length of the value (in bytes), actual length varies in [base, 2*base)")
+                  "base length of the value (in bytes), actual length VARRRRRRRRies in [base, 2*base)")
               .create('v');
 
       Option wordLen =

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIPC.java
@@ -64,7 +64,7 @@ public class TestIPC {
 
   /**
    * Flag used to turn off the fault injection behavior
-   * of the various writables.
+   * of the VARRRRRRRRious writables.
    **/
   static boolean WRITABLE_FAULTS_ENABLED = true;
   
@@ -636,7 +636,7 @@ public class TestIPC {
   }
   
   /**
-   * Wireshark traces collected from various client versions. These enable
+   * Wireshark traces collected from VARRRRRRRRious client versions. These enable
    * us to test that old versions of the IPC stack will receive the correct
    * responses so that they will throw a meaningful error message back
    * to the user.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/lib/TestMetricsRegistry.java
@@ -33,7 +33,7 @@ import static org.apache.hadoop.test.MetricsAsserts.*;
 public class TestMetricsRegistry {
 
   /**
-   * Test various factory methods
+   * Test VARRRRRRRRious factory methods
    */
   @Test public void testNewMetrics() {
     final MetricsRegistry r = new MetricsRegistry("test");

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleStat.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/metrics2/util/TestSampleStat.java
@@ -34,7 +34,7 @@ public class TestSampleStat {
     SampleStat stat = new SampleStat();
     assertEquals("num samples", 0, stat.numSamples());
     assertEquals("mean", 0.0, stat.mean(), EPSILON);
-    assertEquals("variance", 0.0, stat.variance(), EPSILON);
+    assertEquals("VARRRRRRRRiance", 0.0, stat.VARRRRRRRRiance(), EPSILON);
     assertEquals("stddev", 0.0, stat.stddev(), EPSILON);
     assertEquals("min", Double.MAX_VALUE, stat.min(), EPSILON);
     assertEquals("max", Double.MIN_VALUE, stat.max(), EPSILON);
@@ -42,7 +42,7 @@ public class TestSampleStat {
     stat.add(3);
     assertEquals("num samples", 1L, stat.numSamples());
     assertEquals("mean", 3.0, stat.mean(), EPSILON);
-    assertEquals("variance", 0.0, stat.variance(), EPSILON);
+    assertEquals("VARRRRRRRRiance", 0.0, stat.VARRRRRRRRiance(), EPSILON);
     assertEquals("stddev", 0.0, stat.stddev(), EPSILON);
     assertEquals("min", 3.0, stat.min(), EPSILON);
     assertEquals("max", 3.0, stat.max(), EPSILON);
@@ -50,7 +50,7 @@ public class TestSampleStat {
     stat.add(2).add(1);
     assertEquals("num samples", 3L, stat.numSamples());
     assertEquals("mean", 2.0, stat.mean(), EPSILON);
-    assertEquals("variance", 1.0, stat.variance(), EPSILON);
+    assertEquals("VARRRRRRRRiance", 1.0, stat.VARRRRRRRRiance(), EPSILON);
     assertEquals("stddev", 1.0, stat.stddev(), EPSILON);
     assertEquals("min", 1.0, stat.min(), EPSILON);
     assertEquals("max", 3.0, stat.max(), EPSILON);
@@ -58,7 +58,7 @@ public class TestSampleStat {
     stat.reset();
     assertEquals("num samples", 0, stat.numSamples());
     assertEquals("mean", 0.0, stat.mean(), EPSILON);
-    assertEquals("variance", 0.0, stat.variance(), EPSILON);
+    assertEquals("VARRRRRRRRiance", 0.0, stat.VARRRRRRRRiance(), EPSILON);
     assertEquals("stddev", 0.0, stat.stddev(), EPSILON);
     assertEquals("min", Double.MAX_VALUE, stat.min(), EPSILON);
     assertEquals("max", Double.MIN_VALUE, stat.max(), EPSILON);

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/record/RecordBench.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/record/RecordBench.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Method;
 import java.util.Random;
 
 /**
- * Benchmark for various types of serializations
+ * Benchmark for VARRRRRRRRious types of serializations
  */
 public class RecordBench {
   

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/authorize/TestAccessControlList.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/authorize/TestAccessControlList.java
@@ -182,7 +182,7 @@ public class TestAccessControlList {
   }
 
   // Check if AccessControlList.toString() works as expected.
-  // Also validate if getAclString() for various cases.
+  // Also validate if getAclString() for VARRRRRRRRious cases.
   @Test
   public void testAclString() {
     AccessControlList acl;

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestProtoUtil.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestProtoUtil.java
@@ -31,7 +31,7 @@ import com.google.protobuf.CodedOutputStream;
 public class TestProtoUtil {
   
   /**
-   * Values to test encoding as variable length integers
+   * Values to test encoding as VARRRRRRRRiable length integers
    */
   private static final int[] TEST_VINT_VALUES = new int[] {
     0, 1, -1, 127, 128, 129, 255, 256, 257,
@@ -41,7 +41,7 @@ public class TestProtoUtil {
   };
 
   /**
-   * Test that readRawVarint32 is compatible with the varints encoded
+   * Test that readRawVarint32 is compatible with the VARRRRRRRRints encoded
    * by ProtoBuf's CodedOutputStream.
    */
   @Test

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestPureJavaCrc32.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestPureJavaCrc32.java
@@ -242,7 +242,7 @@ public class TestPureJavaCrc32 {
         doBench(c, bytes, 2101, null);
       }
 
-      // Test on a variety of sizes
+      // Test on a VARRRRRRRRiety of sizes
       for (int size = 1; size < MAX_LEN; size *= 2) {
         out.printf("|");
         printCell(String.valueOf(size), title.length()+1, out);

--- a/hadoop-common-project/hadoop-common/src/test/system/java/org/apache/hadoop/test/system/AbstractDaemonClient.java
+++ b/hadoop-common-project/hadoop-common/src/test/system/java/org/apache/hadoop/test/system/AbstractDaemonClient.java
@@ -163,8 +163,8 @@ public abstract class AbstractDaemonClient<PROXY extends DaemonProtocol> {
   }
 
   /**
-   * Abstract method to retrieve the name of a daemon specific env. var
-   * @return name of Hadoop environment variable containing a daemon options
+   * Abstract method to retrieve the name of a daemon specific env. VARRRRRRRR
+   * @return name of Hadoop environment VARRRRRRRRiable containing a daemon options
    */
   abstract public String getHadoopOptsEnvName ();
 
@@ -184,16 +184,16 @@ public abstract class AbstractDaemonClient<PROXY extends DaemonProtocol> {
    * Checks remote daemon process info to see if certain JMX sys. properties
    * are available and reckon if the JMX service is enabled on the remote side
    *
-   * @param envivar name of an evironment variable to be searched
+   * @param enviVARRRRRRRR name of an evironment VARRRRRRRRiable to be searched
    * @return <code>boolean</code> code indicating availability of remote JMX
    * @throws IOException is throws in case of communication errors
    */
-  protected boolean isJmxEnabled(String envivar) throws IOException {
+  protected boolean isJmxEnabled(String enviVARRRRRRRR) throws IOException {
     if (jmxEnabled != null) return jmxEnabled;
     boolean ret = false;
     String jmxRemoteString = "-Dcom.sun.management.jmxremote";
-    String hadoopOpts = getProcessInfo().getEnv().get(envivar);
-    LOG.debug("Looking into " + hadoopOpts + " from " + envivar);
+    String hadoopOpts = getProcessInfo().getEnv().get(enviVARRRRRRRR);
+    LOG.debug("Looking into " + hadoopOpts + " from " + enviVARRRRRRRR);
     List<String> options = Arrays.asList(hadoopOpts.split(" "));
     ret = options.contains(jmxRemoteString);
     jmxEnabled = ret;
@@ -202,7 +202,7 @@ public abstract class AbstractDaemonClient<PROXY extends DaemonProtocol> {
 
   /**
    * Checks remote daemon process info to find remote JMX server port number
-   * By default this method will look into "HADOOP_OPTS" variable only.
+   * By default this method will look into "HADOOP_OPTS" VARRRRRRRRiable only.
    * @return number of remote JMX server or -1 if it can't be found
    * @throws IOException is throws in case of communication errors
    * @throws IllegalArgumentException if non-integer port is set
@@ -216,18 +216,18 @@ public abstract class AbstractDaemonClient<PROXY extends DaemonProtocol> {
   /**
    * Checks remote daemon process info to find remote JMX server port number
    *
-   * @param envivar name of the env. var. to look for JMX specific settings
+   * @param enviVARRRRRRRR name of the env. VARRRRRRRR. to look for JMX specific settings
    * @return number of remote JMX server or -1 if it can't be found
    * @throws IOException is throws in case of communication errors
    * @throws IllegalArgumentException if non-integer port is set
    *  in the remote process info
    */
-  protected int getJmxPortNumber(final String envivar) throws
+  protected int getJmxPortNumber(final String enviVARRRRRRRR) throws
       IOException, IllegalArgumentException {
     if (jmxPortNumber != -1) return jmxPortNumber;
     String jmxPortString = "-Dcom.sun.management.jmxremote.port";
 
-    String hadoopOpts = getProcessInfo().getEnv().get(envivar);
+    String hadoopOpts = getProcessInfo().getEnv().get(enviVARRRRRRRR);
     int portNumber = -1;
     boolean found = false;
     String[] options = hadoopOpts.split(" ");

--- a/hadoop-common-project/hadoop-common/src/test/system/java/org/apache/hadoop/test/system/ProcessInfo.java
+++ b/hadoop-common-project/hadoop-common/src/test/system/java/org/apache/hadoop/test/system/ProcessInfo.java
@@ -36,7 +36,7 @@ public interface ProcessInfo extends Writable {
   /**
    * Get the environment that was used to start the Daemon process.<br/>
    * 
-   * @return the environment variable list.
+   * @return the environment VARRRRRRRRiable list.
    */
   public Map<String,String> getEnv();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/Instrumentation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/Instrumentation.java
@@ -40,10 +40,10 @@ public interface Instrumentation {
 
   public void addCron(String group, String name, Cron cron);
 
-  public void addVariable(String group, String name, Variable<?> variable);
+  public void addVariable(String group, String name, Variable<?> VARRRRRRRRiable);
 
   //sampling happens once a second
-  public void addSampler(String group, String name, int samplingSize, Variable<Long> variable);
+  public void addSampler(String group, String name, int samplingSize, Variable<Long> VARRRRRRRRiable);
 
   public Map<String, Map<String, ?>> getSnapshot();
 

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/instrumentation/InstrumentationService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/service/instrumentation/InstrumentationService.java
@@ -45,11 +45,11 @@ public class InstrumentationService extends BaseService implements Instrumentati
   private int timersSize;
   private Lock counterLock;
   private Lock timerLock;
-  private Lock variableLock;
+  private Lock VARRRRRRRRiableLock;
   private Lock samplerLock;
   private Map<String, Map<String, AtomicLong>> counters;
   private Map<String, Map<String, Timer>> timers;
-  private Map<String, Map<String, VariableHolder>> variables;
+  private Map<String, Map<String, VariableHolder>> VARRRRRRRRiables;
   private Map<String, Map<String, Sampler>> samplers;
   private List<Sampler> samplersList;
   private Map<String, Map<String, ?>> all;
@@ -64,12 +64,12 @@ public class InstrumentationService extends BaseService implements Instrumentati
     timersSize = getServiceConfig().getInt(CONF_TIMERS_SIZE, 10);
     counterLock = new ReentrantLock();
     timerLock = new ReentrantLock();
-    variableLock = new ReentrantLock();
+    VARRRRRRRRiableLock = new ReentrantLock();
     samplerLock = new ReentrantLock();
     Map<String, VariableHolder> jvmVariables = new ConcurrentHashMap<String, VariableHolder>();
     counters = new ConcurrentHashMap<String, Map<String, AtomicLong>>();
     timers = new ConcurrentHashMap<String, Map<String, Timer>>();
-    variables = new ConcurrentHashMap<String, Map<String, VariableHolder>>();
+    VARRRRRRRRiables = new ConcurrentHashMap<String, Map<String, VariableHolder>>();
     samplers = new ConcurrentHashMap<String, Map<String, Sampler>>();
     samplersList = new ArrayList<Sampler>();
     all = new LinkedHashMap<String, Map<String, ?>>();
@@ -78,7 +78,7 @@ public class InstrumentationService extends BaseService implements Instrumentati
     all.put("jvm", jvmVariables);
     all.put("counters", (Map) counters);
     all.put("timers", (Map) timers);
-    all.put("variables", (Map) variables);
+    all.put("VARRRRRRRRiables", (Map) VARRRRRRRRiables);
     all.put("samplers", (Map) samplers);
 
     jvmVariables.put("free.memory", new VariableHolder<Long>(new Instrumentation.Variable<Long>() {
@@ -287,19 +287,19 @@ public class InstrumentationService extends BaseService implements Instrumentati
   }
 
   static class VariableHolder<E> implements JSONAware, JSONStreamAware {
-    Variable<E> var;
+    Variable<E> VARRRRRRRR;
 
     public VariableHolder() {
     }
 
-    public VariableHolder(Variable<E> var) {
-      this.var = var;
+    public VariableHolder(Variable<E> VARRRRRRRR) {
+      this.VARRRRRRRR = VARRRRRRRR;
     }
 
     @SuppressWarnings("unchecked")
     private JSONObject getJSON() {
       JSONObject json = new JSONObject();
-      json.put("value", var.getValue());
+      json.put("value", VARRRRRRRR.getValue());
       return json;
     }
 
@@ -316,20 +316,20 @@ public class InstrumentationService extends BaseService implements Instrumentati
   }
 
   @Override
-  public void addVariable(String group, String name, Variable<?> variable) {
-    VariableHolder holder = getToAdd(group, name, VariableHolder.class, variableLock, variables);
-    holder.var = variable;
+  public void addVariable(String group, String name, Variable<?> VARRRRRRRRiable) {
+    VariableHolder holder = getToAdd(group, name, VariableHolder.class, VARRRRRRRRiableLock, VARRRRRRRRiables);
+    holder.VARRRRRRRR = VARRRRRRRRiable;
   }
 
   static class Sampler implements JSONAware, JSONStreamAware {
-    Variable<Long> variable;
+    Variable<Long> VARRRRRRRRiable;
     long[] values;
     private AtomicLong sum;
     private int last;
     private boolean full;
 
-    void init(int size, Variable<Long> variable) {
-      this.variable = variable;
+    void init(int size, Variable<Long> VARRRRRRRRiable) {
+      this.VARRRRRRRRiable = VARRRRRRRRiable;
       values = new long[size];
       sum = new AtomicLong();
       last = 0;
@@ -340,7 +340,7 @@ public class InstrumentationService extends BaseService implements Instrumentati
       long valueGoingOut = values[last];
       full = full || last == (values.length - 1);
       last = (last + 1) % values.length;
-      values[index] = variable.getValue();
+      values[index] = VARRRRRRRRiable.getValue();
       sum.addAndGet(-valueGoingOut + values[index]);
     }
 
@@ -368,11 +368,11 @@ public class InstrumentationService extends BaseService implements Instrumentati
   }
 
   @Override
-  public void addSampler(String group, String name, int samplingSize, Variable<Long> variable) {
+  public void addSampler(String group, String name, int samplingSize, Variable<Long> VARRRRRRRRiable) {
     Sampler sampler = getToAdd(group, name, Sampler.class, samplerLock, samplers);
     samplerLock.lock();
     try {
-      sampler.init(samplingSize, variable);
+      sampler.init(samplingSize, VARRRRRRRRiable);
       samplersList.add(sampler);
     } finally {
       samplerLock.unlock();

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/util/Check.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/main/java/org/apache/hadoop/lib/util/Check.java
@@ -30,14 +30,14 @@ import java.util.regex.Pattern;
 public class Check {
 
   /**
-   * Verifies a variable is not NULL.
+   * Verifies a VARRRRRRRRiable is not NULL.
    *
-   * @param obj the variable to check.
+   * @param obj the VARRRRRRRRiable to check.
    * @param name the name to use in the exception message.
    *
-   * @return the variable.
+   * @return the VARRRRRRRRiable.
    *
-   * @throws IllegalArgumentException if the variable is NULL.
+   * @throws IllegalArgumentException if the VARRRRRRRRiable is NULL.
    */
   public static <T> T notNull(T obj, String name) {
     if (obj == null) {
@@ -67,12 +67,12 @@ public class Check {
   /**
    * Verifies a string is not NULL and not emtpy
    *
-   * @param str the variable to check.
+   * @param str the VARRRRRRRRiable to check.
    * @param name the name to use in the exception message.
    *
-   * @return the variable.
+   * @return the VARRRRRRRRiable.
    *
-   * @throws IllegalArgumentException if the variable is NULL or empty.
+   * @throws IllegalArgumentException if the VARRRRRRRRiable is NULL or empty.
    */
   public static String notEmpty(String str, String name) {
     if (str == null) {
@@ -90,7 +90,7 @@ public class Check {
    * @param list the list to check.
    * @param name the name to use in the exception message.
    *
-   * @return the variable.
+   * @return the VARRRRRRRRiable.
    *
    * @throws IllegalArgumentException if the string list has NULL or empty
    * elements.

--- a/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/instrumentation/TestInstrumentationService.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-httpfs/src/test/java/org/apache/hadoop/lib/service/instrumentation/TestInstrumentationService.java
@@ -230,7 +230,7 @@ public class TestInstrumentationService extends HTestCase {
   @Test
   public void sampler() throws Exception {
     final long value[] = new long[1];
-    Instrumentation.Variable<Long> var = new Instrumentation.Variable<Long>() {
+    Instrumentation.Variable<Long> VARRRRRRRR = new Instrumentation.Variable<Long>() {
       @Override
       public Long getValue() {
         return value[0];
@@ -238,7 +238,7 @@ public class TestInstrumentationService extends HTestCase {
     };
 
     InstrumentationService.Sampler sampler = new InstrumentationService.Sampler();
-    sampler.init(4, var);
+    sampler.init(4, VARRRRRRRR);
     Assert.assertEquals(sampler.getRate(), 0f, 0.0001);
     sampler.sample();
     Assert.assertEquals(sampler.getRate(), 0f, 0.0001);
@@ -270,23 +270,23 @@ public class TestInstrumentationService extends HTestCase {
   }
 
   @Test
-  public void variableHolder() throws Exception {
-    InstrumentationService.VariableHolder<String> variableHolder =
+  public void VARRRRRRRRiableHolder() throws Exception {
+    InstrumentationService.VariableHolder<String> VARRRRRRRRiableHolder =
       new InstrumentationService.VariableHolder<String>();
 
-    variableHolder.var = new Instrumentation.Variable<String>() {
+    VARRRRRRRRiableHolder.VARRRRRRRR = new Instrumentation.Variable<String>() {
       @Override
       public String getValue() {
         return "foo";
       }
     };
 
-    JSONObject json = (JSONObject) new JSONParser().parse(variableHolder.toJSONString());
+    JSONObject json = (JSONObject) new JSONParser().parse(VARRRRRRRRiableHolder.toJSONString());
     Assert.assertEquals(json.size(), 1);
     Assert.assertEquals(json.get("value"), "foo");
 
     StringWriter writer = new StringWriter();
-    variableHolder.writeJSONString(writer);
+    VARRRRRRRRiableHolder.writeJSONString(writer);
     writer.close();
     json = (JSONObject) new JSONParser().parse(writer.toString());
     Assert.assertEquals(json.size(), 1);
@@ -321,21 +321,21 @@ public class TestInstrumentationService extends HTestCase {
     cron.stop();
     instrumentation.addCron("g", "t", cron);
 
-    Instrumentation.Variable<String> var = new Instrumentation.Variable<String>() {
+    Instrumentation.Variable<String> VARRRRRRRR = new Instrumentation.Variable<String>() {
       @Override
       public String getValue() {
         return "foo";
       }
     };
-    instrumentation.addVariable("g", "v", var);
+    instrumentation.addVariable("g", "v", VARRRRRRRR);
 
-    Instrumentation.Variable<Long> varToSample = new Instrumentation.Variable<Long>() {
+    Instrumentation.Variable<Long> VARRRRRRRRToSample = new Instrumentation.Variable<Long>() {
       @Override
       public Long getValue() {
         return 1L;
       }
     };
-    instrumentation.addSampler("g", "s", 10, varToSample);
+    instrumentation.addSampler("g", "s", 10, VARRRRRRRRToSample);
 
     Map<String, ?> snapshot = instrumentation.getSnapshot();
     Assert.assertNotNull(snapshot.get("os-env"));
@@ -343,7 +343,7 @@ public class TestInstrumentationService extends HTestCase {
     Assert.assertNotNull(snapshot.get("jvm"));
     Assert.assertNotNull(snapshot.get("counters"));
     Assert.assertNotNull(snapshot.get("timers"));
-    Assert.assertNotNull(snapshot.get("variables"));
+    Assert.assertNotNull(snapshot.get("VARRRRRRRRiables"));
     Assert.assertNotNull(snapshot.get("samplers"));
     Assert.assertNotNull(((Map<String, String>) snapshot.get("os-env")).get("PATH"));
     Assert.assertNotNull(((Map<String, String>) snapshot.get("sys-props")).get("java.version"));
@@ -352,12 +352,12 @@ public class TestInstrumentationService extends HTestCase {
     Assert.assertNotNull(((Map<String, ?>) snapshot.get("jvm")).get("total.memory"));
     Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("counters")).get("g"));
     Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("timers")).get("g"));
-    Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("variables")).get("g"));
+    Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("VARRRRRRRRiables")).get("g"));
     Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("samplers")).get("g"));
     Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("counters")).get("g").get("c"));
     Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("counters")).get("g").get("c1"));
     Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("timers")).get("g").get("t"));
-    Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("variables")).get("g").get("v"));
+    Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("VARRRRRRRRiables")).get("g").get("v"));
     Assert.assertNotNull(((Map<String, Map<String, Object>>) snapshot.get("samplers")).get("g").get("s"));
 
     StringWriter writer = new StringWriter();
@@ -381,13 +381,13 @@ public class TestInstrumentationService extends HTestCase {
 
     final AtomicInteger count = new AtomicInteger();
 
-    Instrumentation.Variable<Long> varToSample = new Instrumentation.Variable<Long>() {
+    Instrumentation.Variable<Long> VARRRRRRRRToSample = new Instrumentation.Variable<Long>() {
       @Override
       public Long getValue() {
         return (long) count.incrementAndGet();
       }
     };
-    instrumentation.addSampler("g", "s", 10, varToSample);
+    instrumentation.addSampler("g", "s", 10, VARRRRRRRRToSample);
 
     sleep(2000);
     int i = count.get();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSClient.java
@@ -179,7 +179,7 @@ public class DFSClient implements java.io.Closeable {
           DFS_BYTES_PER_CHECKSUM_DEFAULT);
       socketTimeout = conf.getInt(DFS_CLIENT_SOCKET_TIMEOUT_KEY,
           HdfsServerConstants.READ_TIMEOUT);
-      /** dfs.write.packet.size is an internal config variable */
+      /** dfs.write.packet.size is an internal config VARRRRRRRRiable */
       writePacketSize = conf.getInt(DFS_CLIENT_WRITE_PACKET_SIZE_KEY,
           DFS_CLIENT_WRITE_PACKET_SIZE_DEFAULT);
       defaultBlockSize = conf.getLong(DFS_BLOCK_SIZE_KEY,
@@ -384,7 +384,7 @@ public class DFSClient implements java.io.Closeable {
   
   /**
    * Close connections the Namenode.
-   * The namenode variable is either a rpcProxy passed by a test or 
+   * The namenode VARRRRRRRRiable is either a rpcProxy passed by a test or 
    * created using the protocolTranslator which is closeable.
    * If closeable then call close, else close using RPC.stopProxy().
    */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSInputStream.java
@@ -51,7 +51,7 @@ import org.apache.hadoop.security.token.Token;
 
 /****************************************************************
  * DFSInputStream provides bytes from a named file.  It handles 
- * negotiation of the namenode and various datanodes as necessary.
+ * negotiation of the namenode and VARRRRRRRRious datanodes as necessary.
  ****************************************************************/
 @InterfaceAudience.Private
 public class DFSInputStream extends FSInputStream {
@@ -72,7 +72,7 @@ public class DFSInputStream extends FSInputStream {
   private long blockEnd = -1;
 
   /**
-   * This variable tracks the number of failures since the start of the
+   * This VARRRRRRRRiable tracks the number of failures since the start of the
    * most recent user-facing operation. That is to say, it should be reset
    * whenever the user makes a call on this stream, and if at any point
    * during the retry logic, the failure count exceeds a threshold,

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -1317,7 +1317,7 @@ class DFSOutputStream extends FSOutputSummer implements Syncable {
           dataQueue.wait();
         } catch (InterruptedException e) {
           // If we get interrupted while waiting to queue data, we still need to get rid
-          // of the current packet. This is because we have an invariant that if
+          // of the current packet. This is because we have an inVARRRRRRRRiant that if
           // currentPacket gets full, it will get queued before the next writeChunk.
           //
           // Rather than wait around for space in the queue, we should instead try to

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolR23Compatible/BlocksWithLocationsWritable.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocolR23Compatible/BlocksWithLocationsWritable.java
@@ -61,7 +61,7 @@ public class BlocksWithLocationsWritable implements Writable {
     /** deserialization method */
     public void readFields(DataInput in) throws IOException {
       block.readFields(in);
-      int len = WritableUtils.readVInt(in); // variable length integer
+      int len = WritableUtils.readVInt(in); // VARRRRRRRRiable length integer
       datanodeIDs = new String[len];
       for(int i=0; i<len; i++) {
         datanodeIDs[i] = Text.readString(in);
@@ -71,7 +71,7 @@ public class BlocksWithLocationsWritable implements Writable {
     /** serialization method */
     public void write(DataOutput out) throws IOException {
       block.write(out);
-      WritableUtils.writeVInt(out, datanodeIDs.length); // variable length int
+      WritableUtils.writeVInt(out, datanodeIDs.length); // VARRRRRRRRiable length int
       for(String id:datanodeIDs) {
         Text.writeString(out, id);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/BlockManager.java
@@ -165,7 +165,7 @@ public class BlockManager {
   /** The maximum number of entries returned by getCorruptInodes() */
   final int maxCorruptFilesReturned;
 
-  /** variable to enable check for enough racks */
+  /** VARRRRRRRRiable to enable check for enough racks */
   final boolean shouldCheckForEnoughRacks;
 
   /** Last block index used for replication work. */
@@ -1577,7 +1577,7 @@ public class BlockManager {
   }
 
   /*
-   * The next two methods test the various cases under which we must conclude
+   * The next two methods test the VARRRRRRRRious cases under which we must conclude
    * the replica is corrupt, or under construction.  These are laid out
    * as switch statements, on the theory that it is easier to understand
    * the combinatorics of reportedState and ucState that way.  It should be

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeDescriptor.java
@@ -106,7 +106,7 @@ public class DatanodeDescriptor extends DatanodeInfo {
   // A system administrator can tune the balancer bandwidth parameter
   // (dfs.balance.bandwidthPerSec) dynamically by calling
   // "dfsadmin -setBalanacerBandwidth <newbandwidth>", at which point the
-  // following 'bandwidth' variable gets updated with the new value for each
+  // following 'bandwidth' VARRRRRRRRiable gets updated with the new value for each
   // node. Once the heartbeat command is issued to update the value on the
   // specified datanode, this value will be set back to 0.
   private long bandwidth;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/blockmanagement/DatanodeManager.java
@@ -931,7 +931,7 @@ public class DatanodeManager {
    * A system administrator can tune the balancer bandwidth parameter
    * (dfs.datanode.balance.bandwidthPerSec) dynamically by calling
    * "dfsadmin -setBalanacerBandwidth newbandwidth", at which point the
-   * following 'bandwidth' variable gets updated with the new value for each
+   * following 'bandwidth' VARRRRRRRRiable gets updated with the new value for each
    * node. Once the heartbeat command is issued to update the value on the
    * specified datanode, this value will be set back to 0.
    *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataStorage.java
@@ -76,7 +76,7 @@ public class DataStorage extends Storage {
   private static final Pattern PRE_GENSTAMP_META_FILE_PATTERN = 
     Pattern.compile("(.*blk_[-]*\\d+)\\.meta$");
   
-  /** Access to this variable is guarded by "this" */
+  /** Access to this VARRRRRRRRiable is guarded by "this" */
   private String storageID;
 
   // flag to ensure initialzing storage occurs only once

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DatanodeJspHelper.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DatanodeJspHelper.java
@@ -286,7 +286,7 @@ public class DatanodeJspHelper {
     final DFSClient dfs = getDFSClient(ugi, namenodeAddress, conf);
     List<LocatedBlock> blocks = dfs.getNamenode().getBlockLocations(filename, 0,
         Long.MAX_VALUE).getLocatedBlocks();
-    // Add the various links for looking at the file contents
+    // Add the VARRRRRRRRious links for looking at the file contents
     // URL for downloading the full file
     String downloadUrl = "http://" + req.getServerName() + ":"
         + req.getServerPort() + "/streamFile" + ServletUtil.encodePath(filename)

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/metrics/DataNodeMetrics.java
@@ -34,12 +34,12 @@ import org.apache.hadoop.metrics2.source.JvmMetrics;
 
 /**
  *
- * This class is for maintaining  the various DataNode statistics
+ * This class is for maintaining  the VARRRRRRRRious DataNode statistics
  * and publishing them through the metrics interfaces.
  * This also registers the JMX MBean for RPC.
  * <p>
- * This class has a number of metrics variables that are publicly accessible;
- * these variables (objects) have methods to update their values;
+ * This class has a number of metrics VARRRRRRRRiables that are publicly accessible;
+ * these VARRRRRRRRiables (objects) have methods to update their values;
  *  for example:
  *  <p> {@link #blocksRead}.inc()
  *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSEditLog.java
@@ -100,7 +100,7 @@ public class FSEditLog  {
   private volatile boolean isAutoSyncScheduled = false;
   
   // Used to exit in the event of a failure to sync to all journals. It's a
-  // member variable so it can be swapped out for testing.
+  // member VARRRRRRRRiable so it can be swapped out for testing.
   private Runtime runtime = Runtime.getRuntime();
 
   // these are statistics counters.
@@ -456,7 +456,7 @@ public class FSEditLog  {
           doneWithAutoSyncScheduling();
         }
         //editLogStream may become null,
-        //so store a local variable for flush.
+        //so store a local VARRRRRRRRiable for flush.
         logStream = editLogStream;
       }
       

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageSerialization.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSImageSerialization.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 
 /**
- * Static utility functions for serializing various pieces of data in the correct
+ * Static utility functions for serializing VARRRRRRRRious pieces of data in the correct
  * format for the FSImage file.
  *
  * Some members are currently public for the benefit of the Offline Image Viewer

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FileJournalManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FileJournalManager.java
@@ -306,7 +306,7 @@ class FileJournalManager implements JournalManager {
 
   /** 
    * Find the maximum transaction in the journal.
-   * This gets stored in a member variable, as corrupt edit logs
+   * This gets stored in a member VARRRRRRRRiable, as corrupt edit logs
    * will be moved aside, but we still need to remember their first
    * tranaction id in the case that it was the maximum transaction in
    * the journal.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/NameNodeMetrics.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/metrics/NameNodeMetrics.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.metrics2.source.JvmMetrics;
 
 /**
- * This class is for maintaining  the various NameNode activity statistics
+ * This class is for maintaining  the VARRRRRRRRious NameNode activity statistics
  * and publishing them through the metrics interfaces.
  */
 @Metrics(name="NameNodeActivity", about="NameNode metrics", context="dfs")

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/BlocksWithLocations.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/BlocksWithLocations.java
@@ -70,7 +70,7 @@ public class BlocksWithLocations implements Writable {
     /** deserialization method */
     public void readFields(DataInput in) throws IOException {
       block.readFields(in);
-      int len = WritableUtils.readVInt(in); // variable length integer
+      int len = WritableUtils.readVInt(in); // VARRRRRRRRiable length integer
       datanodeIDs = new String[len];
       for(int i=0; i<len; i++) {
         datanodeIDs[i] = Text.readString(in);
@@ -80,7 +80,7 @@ public class BlocksWithLocations implements Writable {
     /** serialization method */
     public void write(DataOutput out) throws IOException {
       block.write(out);
-      WritableUtils.writeVInt(out, datanodeIDs.length); // variable length int
+      WritableUtils.writeVInt(out, datanodeIDs.length); // VARRRRRRRRiable length int
       for(String id:datanodeIDs) {
         Text.writeString(out, id);
       }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocol/DatanodeProtocol.java
@@ -162,7 +162,7 @@ public interface DatanodeProtocol extends VersionedProtocol {
    * This is a very general way to send a command to the name-node during
    * distributed upgrade process.
    * 
-   * The generosity is because the variety of upgrade commands is unpredictable.
+   * The generosity is because the VARRRRRRRRiety of upgrade commands is unpredictable.
    * The reply from the name-node is also received in the form of an upgrade 
    * command. 
    * 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocolR23Compatible/DatanodeWireProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/protocolR23Compatible/DatanodeWireProtocol.java
@@ -151,7 +151,7 @@ public interface DatanodeWireProtocol extends VersionedProtocol {
    * This is a very general way to send a command to the name-node during
    * distributed upgrade process.
    * 
-   * The generosity is because the variety of upgrade commands is unpredictable.
+   * The generosity is because the VARRRRRRRRiety of upgrade commands is unpredictable.
    * The reply from the name-node is also received in the form of an upgrade 
    * command. 
    * 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/tools/DFSck.java
@@ -227,7 +227,7 @@ public class DFSck extends Configured implements Tool {
     // Derive the nameservice ID from the filesystem URI.
     // The URI may have been provided by a human, and the server name may be
     // aliased, so compare InetSocketAddresses instead of URI strings, and
-    // test against both possible variants of RPC address.
+    // test against both possible VARRRRRRRRiants of RPC address.
     InetSocketAddress namenode = 
       NameNode.getAddress(dfs.getUri().getAuthority());
     

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/resources/Param.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/web/resources/Param.java
@@ -91,12 +91,12 @@ public abstract class Param<T, D extends Param.Domain<T>> {
     /** Parse the given string.
      * @return the parameter value represented by the string.
      */
-    public final T parse(final String varName, final String str) {
+    public final T parse(final String VARRRRRRRRName, final String str) {
       try {
         return str != null && str.trim().length() > 0 ? parse(str) : null;
       } catch(Exception e) {
         throw new IllegalArgumentException("Failed to parse \"" + str
-            + "\" for the parameter " + varName
+            + "\" for the parameter " + VARRRRRRRRName
             + ".  The value must be in the domain " + getDomain(), e);
       }
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestClientBlockVerification.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestClientBlockVerification.java
@@ -97,7 +97,7 @@ public class TestClientBlockVerification {
   }
 
   /**
-   * Test various unaligned reads to make sure that we properly
+   * Test VARRRRRRRRious unaligned reads to make sure that we properly
    * account even when we don't start or end on a checksum boundary
    */
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestCrcCorruption.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestCrcCorruption.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.io.IOUtils;
  *  5. Swaps two meta files, i.e the format of the meta files 
  *     are valid but their CRCs do not match with their corresponding 
  *     data blocks
- * The above tests are run for varied values of dfs.bytes-per-checksum 
+ * The above tests are run for VARRRRRRRRied values of dfs.bytes-per-checksum 
  * and dfs.blocksize. It tests for the case when the meta file is 
  * multiple blocks.
  *

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSRollback.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSRollback.java
@@ -41,7 +41,7 @@ import com.google.common.collect.Lists;
 
 /**
 * This test ensures the appropriate response (successful or failure) from
-* the system when the system is rolled back under various storage state and
+* the system when the system is rolled back under VARRRRRRRRious storage state and
 * version conditions.
 */
 public class TestDFSRollback extends TestCase {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSShell.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSShell.java
@@ -918,7 +918,7 @@ public class TestDFSShell extends TestCase {
     cluster.shutdown();
   }
   /**
-   * Tests various options of DFSShell.
+   * Tests VARRRRRRRRious options of DFSShell.
    */
   public void testDFSShell() throws IOException {
     Configuration conf = new HdfsConfiguration();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStorageStateRecovery.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSStorageStateRecovery.java
@@ -32,7 +32,7 @@ import static org.apache.hadoop.hdfs.server.common.HdfsServerConstants.NodeType.
 
 /**
 * This test ensures the appropriate response (successful or failure) from
-* the system when the system is started under various storage state and
+* the system when the system is started under VARRRRRRRRious storage state and
 * version conditions.
 */
 public class TestDFSStorageStateRecovery extends TestCase {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUpgrade.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.*;
 
 /**
 * This test ensures the appropriate response (successful or failure) from
-* the system when the system is upgraded under various storage state and
+* the system when the system is upgraded under VARRRRRRRRious storage state and
 * version conditions.
 */
 public class TestDFSUpgrade {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUpgradeFromImage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDFSUpgradeFromImage.java
@@ -39,7 +39,7 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * This tests data transfer protocol handling in the Datanode. It sends
- * various forms of wrong data and verifies that Datanode handles it well.
+ * VARRRRRRRRious forms of wrong data and verifies that Datanode handles it well.
  * 
  * This test uses the following two file from src/test/.../dfs directory :
  *   1) hadoop-version-dfs-dir.tgz : contains DFS directories.

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestDataTransferProtocol.java
@@ -65,7 +65,7 @@ import org.mockito.Mockito;
 
 /**
  * This tests data transfer protocol handling in the Datanode. It sends
- * various forms of wrong data and verifies that Datanode handles it well.
+ * VARRRRRRRRious forms of wrong data and verifies that Datanode handles it well.
  */
 public class TestDataTransferProtocol extends TestCase {
   

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileCreation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestFileCreation.java
@@ -54,7 +54,7 @@ import org.apache.log4j.Level;
 
 
 /**
- * This class tests various cases during file creation.
+ * This class tests VARRRRRRRRious cases during file creation.
  */
 public class TestFileCreation extends junit.framework.TestCase {
   static final String DIR = "/" + TestFileCreation.class.getSimpleName() + "/";

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestQuota.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestQuota.java
@@ -730,7 +730,7 @@ public class TestQuota {
       final Path quotaDir2053_C = new Path(quotaDir2053, "C");
       assertTrue(dfs.mkdirs(quotaDir2053_C));
 
-      // Factors to vary the sizes of test files created in each subdir.
+      // Factors to VARRRRRRRRy the sizes of test files created in each subdir.
       // The actual factors are not really important but they allow us to create
       // identifiable file sizes per subdir, which helps during debugging.
       int sizeFactorA = 1;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestSafeMode.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/TestSafeMode.java
@@ -131,7 +131,7 @@ public class TestSafeMode {
   }
 
   /**
-   * Run various fs operations while the NN is in safe mode,
+   * Run VARRRRRRRRious fs operations while the NN is in safe mode,
    * assert that they are either allowed or fail as expected.
    */
   @Test

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/balancer/TestBalancerWithMultipleNameNodes.java
@@ -75,7 +75,7 @@ public class TestBalancerWithMultipleNameNodes {
     Balancer.setBlockMoveWaitTime(1000L) ;
   }
 
-  /** Common objects used in various methods. */
+  /** Common objects used in VARRRRRRRRious methods. */
   private static class Suite {
     final Configuration conf;
     final MiniDFSCluster cluster;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestGetUriFromString.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/common/TestGetUriFromString.java
@@ -37,7 +37,7 @@ public class TestGetUriFromString extends TestCase {
   private static final String ABSOLUTE_PATH_WINDOWS =
     "C:\\Documents and Settings\\All Users";
   private static final String URI_FILE_SCHEMA = "file";
-  private static final String URI_PATH_UNIX = "/var/www";
+  private static final String URI_PATH_UNIX = "/VARRRRRRRR/www";
   private static final String URI_PATH_WINDOWS =
     "/C:/Documents%20and%20Settings/All%20Users";
   private static final String URI_UNIX = URI_FILE_SCHEMA + "://"

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReport.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/datanode/TestBlockReport.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Random;
 
 /**
- * This test simulates a variety of situations when blocks are being
+ * This test simulates a VARRRRRRRRiety of situations when blocks are being
  * intentionally orrupted, unexpectedly modified, and so on before a block
  * report is happening
  */

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCheckpoint.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestCheckpoint.java
@@ -1258,8 +1258,8 @@ public class TestCheckpoint extends TestCase {
       }
     }
     
-    // Validate invariant that files named the same are the same.
-    assertParallelFilesInvariant(cluster, ImmutableList.of(secondary1, secondary2));
+    // Validate inVARRRRRRRRiant that files named the same are the same.
+    assertParallelFilesInVARRRRRRRRiant(cluster, ImmutableList.of(secondary1, secondary2));
 
     // NN should have removed the checkpoint at txid 2 at this point, but has
     // one at txid 6
@@ -1371,8 +1371,8 @@ public class TestCheckpoint extends TestCase {
       }
     }
     
-    // Validate invariant that files named the same are the same.
-    assertParallelFilesInvariant(cluster, ImmutableList.of(secondary1, secondary2));
+    // Validate inVARRRRRRRRiant that files named the same are the same.
+    assertParallelFilesInVARRRRRRRRiant(cluster, ImmutableList.of(secondary1, secondary2));
     // Validate that the NN received checkpoints at expected txids
     // (i.e that both checkpoints went through)
     assertNNHasCheckpoints(cluster, ImmutableList.of(6,8));
@@ -1544,7 +1544,7 @@ public class TestCheckpoint extends TestCase {
       secondary.doCheckpoint();
       
       assertNNHasCheckpoints(cluster, ImmutableList.of(8));
-      assertParallelFilesInvariant(cluster, ImmutableList.of(secondary));
+      assertParallelFilesInVARRRRRRRRiant(cluster, ImmutableList.of(secondary));
     } finally {
       if (currentDir != null) {
         currentDir.setExecutable(true);
@@ -1621,7 +1621,7 @@ public class TestCheckpoint extends TestCase {
       secondary.doCheckpoint();
       
       assertNNHasCheckpoints(cluster, ImmutableList.of(8));
-      assertParallelFilesInvariant(cluster, ImmutableList.of(secondary));
+      assertParallelFilesInVARRRRRRRRiant(cluster, ImmutableList.of(secondary));
     } finally {
       if (currentDir != null) {
         currentDir.setExecutable(true);
@@ -1782,7 +1782,7 @@ public class TestCheckpoint extends TestCase {
    * and NN, they should have the same content too.
    */
   @SuppressWarnings("deprecation")
-  private void assertParallelFilesInvariant(MiniDFSCluster cluster,
+  private void assertParallelFilesInVARRRRRRRRiant(MiniDFSCluster cluster,
       ImmutableList<SecondaryNameNode> secondaries) throws Exception {
     List<File> allCurrentDirs = Lists.newArrayList();
     allCurrentDirs.addAll(getNameNodeCurrentDirs(cluster));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestEditLogRace.java
@@ -52,7 +52,7 @@ import org.mockito.stubbing.Answer;
 import static org.mockito.Mockito.*;
 
 /**
- * This class tests various synchronization bugs in FSEditLog rolling
+ * This class tests VARRRRRRRRious synchronization bugs in FSEditLog rolling
  * and namespace saving.
  */
 public class TestEditLogRace {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSEditLogLoader.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestFSEditLogLoader.java
@@ -196,7 +196,7 @@ public class TestFSEditLogLoader {
     File logFileBak = new File(testDir, logFile.getName() + ".bak");
     Files.copy(logFile, logFileBak);
 
-    // Corrupt the log file in various ways for each txn
+    // Corrupt the log file in VARRRRRRRRious ways for each txn
     for (Map.Entry<Long, Long> entry : offsetToTxId.entrySet()) {
       long txOffset = entry.getKey();
       long txid = entry.getValue();

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestNameEditsConfigs.java
@@ -36,7 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * This class tests various combinations of dfs.namenode.name.dir 
+ * This class tests VARRRRRRRRious combinations of dfs.namenode.name.dir 
  * and dfs.namenode.edits.dir configurations.
  */
 public class TestNameEditsConfigs extends TestCase {
@@ -117,7 +117,7 @@ public class TestNameEditsConfigs extends TestCase {
   }
 
   /**
-   * Test various configuration options of dfs.namenode.name.dir and dfs.namenode.edits.dir
+   * Test VARRRRRRRRious configuration options of dfs.namenode.name.dir and dfs.namenode.edits.dir
    * The test creates files and restarts cluster with different configs.
    * 1. Starts cluster with shared name and edits dirs
    * 2. Restarts cluster by adding additional (different) name and edits dirs
@@ -310,7 +310,7 @@ public class TestNameEditsConfigs extends TestCase {
   }
 
   /**
-   * Test various configuration options of dfs.namenode.name.dir and dfs.namenode.edits.dir
+   * Test VARRRRRRRRious configuration options of dfs.namenode.name.dir and dfs.namenode.edits.dir
    * This test tries to simulate failure scenarios.
    * 1. Start cluster with shared name and edits dir
    * 2. Restart cluster by adding separate name and edits dirs

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSaveNamespace.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestSaveNamespace.java
@@ -57,7 +57,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /**
- * Test various failure scenarios during saveNamespace() operation.
+ * Test VARRRRRRRRious failure scenarios during saveNamespace() operation.
  * Cases covered:
  * <ol>
  * <li>Recover from failure while saving into the second storage directory</li>

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestStartupOptionUpgrade.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/namenode/TestStartupOptionUpgrade.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * This class tests various upgrade cases from earlier versions to current
+ * This class tests VARRRRRRRRious upgrade cases from earlier versions to current
  * version with and without clusterid.
  */
 public class TestStartupOptionUpgrade {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestGSet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/util/TestGSet.java
@@ -169,7 +169,7 @@ public class TestGSet {
   /**
    * A long test,
    * which may take ~5 hours,
-   * with various data sets and parameters.
+   * with VARRRRRRRRious data sets and parameters.
    * If you are changing the implementation,
    * please un-comment the following line in order to run the test.
    */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/MapReduceChildJVM.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapred/MapReduceChildJVM.java
@@ -82,7 +82,7 @@ public class MapReduceChildJVM {
         Environment.LD_LIBRARY_PATH.name(), 
         Environment.PWD.$());
 
-    // Add the env variables passed by the user & admin
+    // Add the env VARRRRRRRRiables passed by the user & admin
     String mapredChildEnv = getChildEnv(conf, task.isMapTask());
     Apps.setEnvFromInputString(environment, mapredChildEnv);
     Apps.setEnvFromInputString(
@@ -167,10 +167,10 @@ public class MapReduceChildJVM {
   }
 
   private static void setupLog4jProperties(Task task,
-      Vector<String> vargs,
+      Vector<String> VARRRRRRRRgs,
       long logSize) {
     String logLevel = getChildLogLevel(task.conf, task.isMapTask()); 
-    MRApps.addLog4jSystemProperties(logLevel, logSize, vargs);
+    MRApps.addLog4jSystemProperties(logLevel, logSize, VARRRRRRRRgs);
   }
 
   public static List<String> getVMCommand(
@@ -180,10 +180,10 @@ public class MapReduceChildJVM {
     TaskAttemptID attemptID = task.getTaskID();
     JobConf conf = task.conf;
 
-    Vector<String> vargs = new Vector<String>(8);
+    Vector<String> VARRRRRRRRgs = new Vector<String>(8);
 
-    vargs.add("exec");
-    vargs.add(Environment.JAVA_HOME.$() + "/bin/java");
+    VARRRRRRRRgs.add("exec");
+    VARRRRRRRRgs.add(Environment.JAVA_HOME.$() + "/bin/java");
 
     // Add child (task) java-vm options.
     //
@@ -217,20 +217,20 @@ public class MapReduceChildJVM {
     javaOpts = javaOpts.replace("@taskid@", attemptID.toString());
     String [] javaOptsSplit = javaOpts.split(" ");
     for (int i = 0; i < javaOptsSplit.length; i++) {
-      vargs.add(javaOptsSplit[i]);
+      VARRRRRRRRgs.add(javaOptsSplit[i]);
     }
 
     String childTmpDir = Environment.PWD.$() + Path.SEPARATOR + "tmp";
-    vargs.add("-Djava.io.tmpdir=" + childTmpDir);
+    VARRRRRRRRgs.add("-Djava.io.tmpdir=" + childTmpDir);
 
     // Setup the log4j prop
     long logSize = TaskLog.getTaskLogLength(conf);
-    setupLog4jProperties(task, vargs, logSize);
+    setupLog4jProperties(task, VARRRRRRRRgs, logSize);
 
     if (conf.getProfileEnabled()) {
       if (conf.getProfileTaskRange(task.isMapTask()
                                    ).isIncluded(task.getPartition())) {
-        vargs.add(
+        VARRRRRRRRgs.add(
             String.format(
                 conf.getProfileParams(), 
                 getTaskLogFile(TaskLog.LogName.PROFILE)
@@ -240,24 +240,24 @@ public class MapReduceChildJVM {
     }
 
     // Add main class and its arguments 
-    vargs.add(YarnChild.class.getName());  // main of Child
+    VARRRRRRRRgs.add(YarnChild.class.getName());  // main of Child
     // pass TaskAttemptListener's address
-    vargs.add(taskAttemptListenerAddr.getAddress().getHostAddress()); 
-    vargs.add(Integer.toString(taskAttemptListenerAddr.getPort())); 
-    vargs.add(attemptID.toString());                      // pass task identifier
+    VARRRRRRRRgs.add(taskAttemptListenerAddr.getAddress().getHostAddress()); 
+    VARRRRRRRRgs.add(Integer.toString(taskAttemptListenerAddr.getPort())); 
+    VARRRRRRRRgs.add(attemptID.toString());                      // pass task identifier
 
     // Finally add the jvmID
-    vargs.add(String.valueOf(jvmID.getId()));
-    vargs.add("1>" + getTaskLogFile(TaskLog.LogName.STDOUT));
-    vargs.add("2>" + getTaskLogFile(TaskLog.LogName.STDERR));
+    VARRRRRRRRgs.add(String.valueOf(jvmID.getId()));
+    VARRRRRRRRgs.add("1>" + getTaskLogFile(TaskLog.LogName.STDOUT));
+    VARRRRRRRRgs.add("2>" + getTaskLogFile(TaskLog.LogName.STDERR));
 
     // Final commmand
     StringBuilder mergedCommand = new StringBuilder();
-    for (CharSequence str : vargs) {
+    for (CharSequence str : VARRRRRRRRgs) {
       mergedCommand.append(str).append(" ");
     }
-    Vector<String> vargsFinal = new Vector<String>(1);
-    vargsFinal.add(mergedCommand.toString());
-    return vargsFinal;
+    Vector<String> VARRRRRRRRgsFinal = new Vector<String>(1);
+    VARRRRRRRRgsFinal.add(mergedCommand.toString());
+    return VARRRRRRRRgsFinal;
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/JobImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/JobImpl.java
@@ -395,7 +395,7 @@ public class JobImpl implements org.apache.hadoop.mapreduce.v2.app.job.Job,
     this.username = System.getProperty("user.name");
     this.jobACLs = aclsManager.constructJobACLs(conf);
     // This "this leak" is okay because the retained pointer is in an
-    //  instance variable.
+    //  instance VARRRRRRRRiable.
     stateMachine = stateMachineFactory.make(this);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskAttemptImpl.java
@@ -480,7 +480,7 @@ public abstract class TaskAttemptImpl implements
     RackResolver.init(conf);
 
     // This "this leak" is okay because the retained pointer is in an
-    //  instance variable.
+    //  instance VARRRRRRRRiable.
     stateMachine = stateMachineFactory.make(this);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TaskImpl.java
@@ -267,7 +267,7 @@ public abstract class TaskImpl implements Task, EventHandler<TaskEvent> {
     nextAttemptNumber = (startCount - 1) * 1000;
 
     // This "this leak" is okay because the retained pointer is in an
-    //  instance variable.
+    //  instance VARRRRRRRRiable.
     stateMachine = stateMachineFactory.make(this);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/DataStatistics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/DataStatistics.java
@@ -46,7 +46,7 @@ public class DataStatistics {
     return count == 0 ? 0.0 : sum/count;
   }
 
-  public synchronized double var() {
+  public synchronized double VARRRRRRRR() {
     // E(X^2) - E(X)^2
     if (count <= 1) {
       return 0.0;
@@ -56,7 +56,7 @@ public class DataStatistics {
   }
 
   public synchronized double std() {
-    return Math.sqrt(this.var());
+    return Math.sqrt(this.VARRRRRRRR());
   }
 
   public synchronized double outlier(float sigma) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/LegacyTaskRuntimeEstimator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/speculate/LegacyTaskRuntimeEstimator.java
@@ -97,19 +97,19 @@ public class LegacyTaskRuntimeEstimator extends StartEndTimesBase {
 
 
       long estimate = -1;
-      long varianceEstimate = -1;
+      long VARRRRRRRRianceEstimate = -1;
 
       // This code assumes that we'll never consider starting a third
       //  speculative task attempt if two are already running for this task
       if (start > 0 && timestamp > start) {
         estimate = (long) ((timestamp - start) / Math.max(0.0001, status.progress));
-        varianceEstimate = (long) (estimate * status.progress / 10);
+        VARRRRRRRRianceEstimate = (long) (estimate * status.progress / 10);
       }
       if (estimateContainer != null) {
         estimateContainer.set(estimate);
       }
       if (estimateVarianceContainer != null) {
-        estimateVarianceContainer.set(varianceEstimate);
+        estimateVarianceContainer.set(VARRRRRRRRianceEstimate);
       }
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AppController.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/AppController.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.yarn.webapp.View;
 import com.google.inject.Inject;
 
 /**
- * This class renders the various pages that the web app supports.
+ * This class renders the VARRRRRRRRious pages that the web app supports.
  */
 public class AppController extends Controller implements AMParams {
   protected final App app;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/JobConfPage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/main/java/org/apache/hadoop/mapreduce/v2/app/webapp/JobConfPage.java
@@ -72,7 +72,7 @@ public class JobConfPage extends AppView {
    * by column.
    */
   private String confPostTableInit() {
-    return "var confInitVals = new Array();\n" +
+    return "VARRRRRRRR confInitVals = new Array();\n" +
     "$('tfoot input').keyup( function () \n{"+
     "  confDataTable.fnFilter( this.value, $('tfoot input').index(this) );\n"+
     "} );\n"+

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/MRApp.java
@@ -447,7 +447,7 @@ public class MRApp extends MRAppMaster {
           newApiCommitter, user, System.currentTimeMillis(), getAllAMInfos());
 
       // This "this leak" is okay because the retained pointer is in an
-      //  instance variable.
+      //  instance VARRRRRRRRiable.
       localStateMachine = localFactory.make(this);
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/job/impl/TestJobImpl.java
@@ -52,7 +52,7 @@ import org.mockito.Mockito;
 
 
 /**
- * Tests various functions of the JobImpl class
+ * Tests VARRRRRRRRious functions of the JobImpl class
  */
 public class TestJobImpl {
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/TestDataStatistics.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-app/src/test/java/org/apache/hadoop/mapreduce/v2/app/speculate/TestDataStatistics.java
@@ -30,7 +30,7 @@ public class TestDataStatistics {
     DataStatistics statistics = new DataStatistics();
     Assert.assertEquals(0, statistics.count(), TOL);
     Assert.assertEquals(0, statistics.mean(), TOL);
-    Assert.assertEquals(0, statistics.var(), TOL);
+    Assert.assertEquals(0, statistics.VARRRRRRRR(), TOL);
     Assert.assertEquals(0, statistics.std(), TOL);
     Assert.assertEquals(0, statistics.outlier(1.0f), TOL);
   }
@@ -40,7 +40,7 @@ public class TestDataStatistics {
     DataStatistics statistics = new DataStatistics(17.29);
     Assert.assertEquals(1, statistics.count(), TOL);
     Assert.assertEquals(17.29, statistics.mean(), TOL);
-    Assert.assertEquals(0, statistics.var(), TOL);
+    Assert.assertEquals(0, statistics.VARRRRRRRR(), TOL);
     Assert.assertEquals(0, statistics.std(), TOL);
     Assert.assertEquals(17.29, statistics.outlier(1.0f), TOL);
   }
@@ -52,7 +52,7 @@ public class TestDataStatistics {
     statistics.add(29);
     Assert.assertEquals(2, statistics.count(), TOL);
     Assert.assertEquals(23.0, statistics.mean(), TOL);
-    Assert.assertEquals(36.0, statistics.var(), TOL);
+    Assert.assertEquals(36.0, statistics.VARRRRRRRR(), TOL);
     Assert.assertEquals(6.0, statistics.std(), TOL);
     Assert.assertEquals(29.0, statistics.outlier(1.0f), TOL);
  }
@@ -63,11 +63,11 @@ public class TestDataStatistics {
     statistics.add(29);
     Assert.assertEquals(2, statistics.count(), TOL);
     Assert.assertEquals(23.0, statistics.mean(), TOL);
-    Assert.assertEquals(36.0, statistics.var(), TOL);
+    Assert.assertEquals(36.0, statistics.VARRRRRRRR(), TOL);
 
     statistics.updateStatistics(17, 29);
     Assert.assertEquals(2, statistics.count(), TOL);
     Assert.assertEquals(29.0, statistics.mean(), TOL);
-    Assert.assertEquals(0.0, statistics.var(), TOL);
+    Assert.assertEquals(0.0, statistics.VARRRRRRRR(), TOL);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapred/LocalJobRunner.java
@@ -260,7 +260,7 @@ public class LocalJobRunner implements ClientProtocol {
 
     /**
      * Initialize the counters that will hold partial-progress from
-     * the various task attempts.
+     * the VARRRRRRRRious task attempts.
      * @param numMaps the number of map tasks in this job.
      */
     private synchronized void initCounters(int numMaps) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/util/MRApps.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-common/src/main/java/org/apache/hadoop/mapreduce/v2/util/MRApps.java
@@ -353,14 +353,14 @@ public class MRApps extends Apps {
    * Add the JVM system properties necessary to configure {@link ContainerLogAppender}.
    * @param logLevel the desired log level (eg INFO/WARN/DEBUG)
    * @param logSize See {@link ContainerLogAppender#setTotalLogFileSize(long)}
-   * @param vargs the argument list to append to
+   * @param VARRRRRRRRgs the argument list to append to
    */
   public static void addLog4jSystemProperties(
-      String logLevel, long logSize, List<String> vargs) {
-    vargs.add("-Dlog4j.configuration=container-log4j.properties");
-    vargs.add("-D" + MRJobConfig.TASK_LOG_DIR + "=" +
+      String logLevel, long logSize, List<String> VARRRRRRRRgs) {
+    VARRRRRRRRgs.add("-Dlog4j.configuration=container-log4j.properties");
+    VARRRRRRRRgs.add("-D" + MRJobConfig.TASK_LOG_DIR + "=" +
         ApplicationConstants.LOG_DIR_EXPANSION_VAR);
-    vargs.add("-D" + MRJobConfig.TASK_LOG_SIZE + "=" + logSize);
-    vargs.add("-Dhadoop.root.logger=" + logLevel + ",CLA"); 
+    VARRRRRRRRgs.add("-D" + MRJobConfig.TASK_LOG_SIZE + "=" + logSize);
+    VARRRRRRRRgs.add("-Dhadoop.root.logger=" + logLevel + ",CLA"); 
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobClient.java
@@ -80,7 +80,7 @@ import org.apache.hadoop.util.ToolRunner;
  *   </li>
  * </ol></p>
  *  
- * Normally the user creates the application, describes various facets of the
+ * Normally the user creates the application, describes VARRRRRRRRious facets of the
  * job via {@link JobConf} and then uses the <code>JobClient</code> to submit 
  * the job and monitor its progress.
  * 
@@ -89,7 +89,7 @@ import org.apache.hadoop.util.ToolRunner;
  *     // Create a new JobConf
  *     JobConf job = new JobConf(new Configuration(), MyJob.class);
  *     
- *     // Specify various job-specific parameters     
+ *     // Specify VARRRRRRRRious job-specific parameters     
  *     job.setJobName("myjob");
  *     
  *     job.setInputPath(new Path("in"));
@@ -111,7 +111,7 @@ import org.apache.hadoop.util.ToolRunner;
  * 
  * <p>However, this also means that the onus on ensuring jobs are complete 
  * (success/failure) lies squarely on the clients. In such situations the 
- * various job-control options are:
+ * VARRRRRRRRious job-control options are:
  * <ol>
  *   <li>
  *   {@link #runJob(JobConf)} : submits the job and returns only after 
@@ -425,7 +425,7 @@ public class JobClient extends CLI {
   Cluster cluster;
   /**
    * Ugi of the client. We store this ugi when the client is created and 
-   * then make sure that the same ugi is used to run the various protocols.
+   * then make sure that the same ugi is used to run the VARRRRRRRRious protocols.
    */
   UserGroupInformation clientUgi;
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/JobConf.java
@@ -89,7 +89,7 @@ import org.apache.log4j.Level;
  *     // Create a new JobConf
  *     JobConf job = new JobConf(new Configuration(), MyJob.class);
  *     
- *     // Specify various job-specific parameters     
+ *     // Specify VARRRRRRRRious job-specific parameters     
  *     job.setJobName("myjob");
  *     
  *     FileInputFormat.setInputPaths(job, new Path("in"));
@@ -188,11 +188,11 @@ public class JobConf extends Configuration {
    * /tmp and to set the heap maximum to be a gigabyte, pass a 'value' of:
    *          -Xmx1024m -verbose:gc -Xloggc:/tmp/@taskid@.gc
    * 
-   * The configuration variable {@link #MAPRED_TASK_ULIMIT} can be used to 
+   * The configuration VARRRRRRRRiable {@link #MAPRED_TASK_ULIMIT} can be used to 
    * control the maximum virtual memory of the child processes.
    * 
-   * The configuration variable {@link #MAPRED_TASK_ENV} can be used to pass 
-   * other environment variables to the child processes.
+   * The configuration VARRRRRRRRiable {@link #MAPRED_TASK_ENV} can be used to pass 
+   * other environment VARRRRRRRRiables to the child processes.
    * 
    * @deprecated Use {@link #MAPRED_MAP_TASK_JAVA_OPTS} or 
    *                 {@link #MAPRED_REDUCE_TASK_JAVA_OPTS}
@@ -211,11 +211,11 @@ public class JobConf extends Configuration {
    * /tmp and to set the heap maximum to be a gigabyte, pass a 'value' of:
    *          -Xmx1024m -verbose:gc -Xloggc:/tmp/@taskid@.gc
    * 
-   * The configuration variable {@link #MAPRED_MAP_TASK_ULIMIT} can be used to 
+   * The configuration VARRRRRRRRiable {@link #MAPRED_MAP_TASK_ULIMIT} can be used to 
    * control the maximum virtual memory of the map processes.
    * 
-   * The configuration variable {@link #MAPRED_MAP_TASK_ENV} can be used to pass 
-   * other environment variables to the map processes.
+   * The configuration VARRRRRRRRiable {@link #MAPRED_MAP_TASK_ENV} can be used to pass 
+   * other environment VARRRRRRRRiables to the map processes.
    */
   public static final String MAPRED_MAP_TASK_JAVA_OPTS = 
     JobContext.MAP_JAVA_OPTS;
@@ -231,11 +231,11 @@ public class JobConf extends Configuration {
    * /tmp and to set the heap maximum to be a gigabyte, pass a 'value' of:
    *          -Xmx1024m -verbose:gc -Xloggc:/tmp/@taskid@.gc
    * 
-   * The configuration variable {@link #MAPRED_REDUCE_TASK_ULIMIT} can be used  
+   * The configuration VARRRRRRRRiable {@link #MAPRED_REDUCE_TASK_ULIMIT} can be used  
    * to control the maximum virtual memory of the reduce processes.
    * 
-   * The configuration variable {@link #MAPRED_REDUCE_TASK_ENV} can be used to 
-   * pass process environment variables to the reduce processes.
+   * The configuration VARRRRRRRRiable {@link #MAPRED_REDUCE_TASK_ENV} can be used to 
+   * pass process environment VARRRRRRRRiables to the reduce processes.
    */
   public static final String MAPRED_REDUCE_TASK_JAVA_OPTS = 
     JobContext.REDUCE_JAVA_OPTS;
@@ -279,12 +279,12 @@ public class JobConf extends Configuration {
    * Configuration key to set the environment of the child map/reduce tasks.
    * 
    * The format of the value is <code>k1=v1,k2=v2</code>. Further it can 
-   * reference existing environment variables via <code>$key</code>.
+   * reference existing environment VARRRRRRRRiables via <code>$key</code>.
    * 
    * Example:
    * <ul>
-   *   <li> A=foo - This will set the env variable A to foo. </li>
-   *   <li> B=$X:c This is inherit tasktracker's X env variable. </li>
+   *   <li> A=foo - This will set the env VARRRRRRRRiable A to foo. </li>
+   *   <li> B=$X:c This is inherit tasktracker's X env VARRRRRRRRiable. </li>
    * </ul>
    * 
    * @deprecated Use {@link #MAPRED_MAP_TASK_ENV} or 
@@ -298,12 +298,12 @@ public class JobConf extends Configuration {
    * map tasks.
    * 
    * The format of the value is <code>k1=v1,k2=v2</code>. Further it can 
-   * reference existing environment variables via <code>$key</code>.
+   * reference existing environment VARRRRRRRRiables via <code>$key</code>.
    * 
    * Example:
    * <ul>
-   *   <li> A=foo - This will set the env variable A to foo. </li>
-   *   <li> B=$X:c This is inherit tasktracker's X env variable. </li>
+   *   <li> A=foo - This will set the env VARRRRRRRRiable A to foo. </li>
+   *   <li> B=$X:c This is inherit tasktracker's X env VARRRRRRRRiable. </li>
    * </ul>
    */
   public static final String MAPRED_MAP_TASK_ENV = JobContext.MAP_ENV;
@@ -313,12 +313,12 @@ public class JobConf extends Configuration {
    * reduce tasks.
    * 
    * The format of the value is <code>k1=v1,k2=v2</code>. Further it can 
-   * reference existing environment variables via <code>$key</code>.
+   * reference existing environment VARRRRRRRRiables via <code>$key</code>.
    * 
    * Example:
    * <ul>
-   *   <li> A=foo - This will set the env variable A to foo. </li>
-   *   <li> B=$X:c This is inherit tasktracker's X env variable. </li>
+   *   <li> A=foo - This will set the env VARRRRRRRRiable A to foo. </li>
+   *   <li> B=$X:c This is inherit tasktracker's X env VARRRRRRRRiable. </li>
    * </ul>
    */
   public static final String MAPRED_REDUCE_TASK_ENV = JobContext.REDUCE_ENV;
@@ -1937,7 +1937,7 @@ public class JobConf extends Configuration {
   }
 
   /**
-   * @deprecated this variable is deprecated and nolonger in use.
+   * @deprecated this VARRRRRRRRiable is deprecated and nolonger in use.
    */
   @Deprecated
   public long getMaxPhysicalMemoryForTask() {
@@ -1958,7 +1958,7 @@ public class JobConf extends Configuration {
   }
 
   static String deprecatedString(String key) {
-    return "The variable " + key + " is no longer used.";
+    return "The VARRRRRRRRiable " + key + " is no longer used.";
   }
 
   private void checkAndWarnDeprecation() {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/MapTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/MapTask.java
@@ -1064,7 +1064,7 @@ class MapTask extends Task {
         valSerializer.serialize(value);
         // It's possible for records to have zero length, i.e. the serializer
         // will perform no writes. To ensure that the boundary conditions are
-        // checked and that the kvindex invariant is maintained, perform a
+        // checked and that the kvindex inVARRRRRRRRiant is maintained, perform a
         // zero-length write into the buffer. The logic monitoring this could be
         // moved into collect, but this is cleaner and inexpensive. For now, it
         // is acceptable.
@@ -1269,7 +1269,7 @@ class MapTask extends Task {
       @Override
       public void write(byte b[], int off, int len)
           throws IOException {
-        // must always verify the invariant that at least METASIZE bytes are
+        // must always verify the inVARRRRRRRRiant that at least METASIZE bytes are
         // available beyond kvindex, even when len == 0
         bufferRemaining -= len;
         if (bufferRemaining <= 0) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/MergeSorter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/MergeSorter.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.io.SequenceFile.Sorter.RawKeyValueIterator;
  * MergeSort. Note that this class is really a wrapper over the actual
  * mergesort implementation that is there in the util package. The main intent
  * of providing this class is to setup the input data for the util.MergeSort
- * algo so that the latter doesn't need to bother about the various data 
+ * algo so that the latter doesn't need to bother about the VARRRRRRRRious data 
  * structures that have been created for the Map output but rather concentrate 
  * on the core algorithm (thereby allowing easy integration of a mergesort
  * implementation). The bridge between this class and the util.MergeSort class

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/Merger.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/Merger.java
@@ -348,13 +348,13 @@ public class Merger {
     }
   }
   
-  // Boolean variable for including/considering final merge as part of sort
+  // Boolean VARRRRRRRRiable for including/considering final merge as part of sort
   // phase or not. This is true in map task, false in reduce task. It is
   // used in calculating mergeProgress.
   static boolean includeFinalMerge = false;
   
   /**
-   * Sets the boolean variable includeFinalMerge to true. Called from
+   * Sets the boolean VARRRRRRRRiable includeFinalMerge to true. Called from
    * map task before calling merge() so that final merge of map task
    * is also considered as part of sort phase.
    */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/PeriodicStatsAccumulator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/PeriodicStatsAccumulator.java
@@ -36,13 +36,13 @@ package org.apache.hadoop.mapred;
 public abstract class PeriodicStatsAccumulator {
   // The range of progress from 0.0D through 1.0D is divided into
   //  count "progress segments".  This object accumulates an
-  //  estimate of the effective value of a time-varying value during
+  //  estimate of the effective value of a time-VARRRRRRRRying value during
   //  the zero-based i'th progress segment, ranging from i/count
   //  through (i+1)/count . 
   // This is an abstract class.  We have two implementations: one
-  //  for monotonically increasing time-dependent variables
+  //  for monotonically increasing time-dependent VARRRRRRRRiables
   //  [currently, CPU time in milliseconds and wallclock time in
-  //  milliseconds] and one for quantities that can vary arbitrarily
+  //  milliseconds] and one for quantities that can VARRRRRRRRy arbitrarily
   //  over time, currently virtual and physical memory used, in
   //  kilobytes. 
   // We carry int's here.  This saves a lot of JVM heap space in the
@@ -89,7 +89,7 @@ public abstract class PeriodicStatsAccumulator {
    *                      reading covers
    * @param newValue the value of the reading at {@code newProgress} 
    *
-   * The class has three instance variables, {@code oldProgress} and
+   * The class has three instance VARRRRRRRRiables, {@code oldProgress} and
    *  {@code oldValue} and {@code currentAccumulation}. 
    *
    * {@code extendInternal} can count on three things: 
@@ -108,7 +108,7 @@ public abstract class PeriodicStatsAccumulator {
 
   // What has to be done when you open a new interval
   /**
-   * initializes the state variables to be ready for a new interval
+   * initializes the state VARRRRRRRRiables to be ready for a new interval
    */
   protected void initializeInterval() {
     state.currentAccumulation = 0.0D;
@@ -126,7 +126,7 @@ public abstract class PeriodicStatsAccumulator {
    * 
    *  <p>For example, if the value was {@code 300} last time with
    *  {@code 0.3}  progress, and count is {@code 5}, and you get a
-   *  new reading with the variable at {@code 700} and progress at
+   *  new reading with the VARRRRRRRRiable at {@code 700} and progress at
    *  {@code 0.7}, you get three calls to {@code extendInternal}:
    *  one extending from progress {@code 0.3} to {@code 0.4} [the
    *  next boundary] with a value of {@code 400}, the next one

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/Queue.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/Queue.java
@@ -59,7 +59,7 @@ class Queue implements Comparable<Queue>{
 
   /**
    * Default constructor is useful in creating the hierarchy.
-   * The variables are populated using mutator methods.
+   * The VARRRRRRRRiables are populated using mutator methods.
    */
   Queue() {
     

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/QueueManager.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/QueueManager.java
@@ -61,7 +61,7 @@ import java.net.URL;
  * Leaf level queues are queues that contain no queues within them. Jobs
  * can be submitted only to leaf level queues.
  * <p/>
- * Queues can be configured with various properties. Some of these
+ * Queues can be configured with VARRRRRRRRious properties. Some of these
  * properties are common to all schedulers, and those are handled by this
  * class. Schedulers might also associate several custom properties with
  * queues. These properties are parsed and maintained per queue by the

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/SkipBadRecords.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/SkipBadRecords.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
 /**
- * Utility class for skip bad records functionality. It contains various 
+ * Utility class for skip bad records functionality. It contains VARRRRRRRRious 
  * settings related to skipping of bad records.
  * 
  * <p>Hadoop provides an optional mode of execution in which the bad records

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/StatePeriodicStats.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/StatePeriodicStats.java
@@ -22,7 +22,7 @@ package org.apache.hadoop.mapred;
  *
  * This class is a concrete PeriodicStatsAccumulator that deals with
  *  measurements where the raw data are a measurement of a
- *  time-varying quantity.  The result in each bucket is the estimate
+ *  time-VARRRRRRRRying quantity.  The result in each bucket is the estimate
  *  of the progress-weighted mean value of that quantity over the
  *  progress range covered by the bucket.
  *

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TaskLog.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/TaskLog.java
@@ -447,7 +447,7 @@ public class TaskLog {
    * @return the modified command that should be run
    * 
    * @deprecated     pidFiles are no more used. Instead pid is exported to
-   *                 env variable JVM_PID.
+   *                 env VARRRRRRRRiable JVM_PID.
    */
   @Deprecated
   public static List<String> captureOutAndError(List<String> setup,
@@ -512,7 +512,7 @@ public class TaskLog {
     String stderr = FileUtil.makeShellPath(stderrFilename);    
     StringBuffer mergedCmd = new StringBuffer();
     
-    // Export the pid of taskJvm to env variable JVM_PID.
+    // Export the pid of taskJvm to env VARRRRRRRRiable JVM_PID.
     // Currently pid is not used on Windows
     if (!Shell.WINDOWS) {
       mergedCmd.append(" export JVM_PID=`echo $$` ; ");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/CombineFileRecordReader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/CombineFileRecordReader.java
@@ -148,7 +148,7 @@ public class CombineFileRecordReader<K, V> implements RecordReader<K, V> {
       curReader =  rrConstructor.newInstance(new Object [] 
                             {split, jc, reporter, Integer.valueOf(idx)});
 
-      // setup some helper config variables.
+      // setup some helper config VARRRRRRRRiables.
       jc.set(JobContext.MAP_INPUT_FILE, split.getPath(idx).toString());
       jc.setLong(JobContext.MAP_INPUT_START, split.getOffset(idx));
       jc.setLong(JobContext.MAP_INPUT_PATH, split.getLength(idx));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/MultithreadedMapRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/MultithreadedMapRunner.java
@@ -242,7 +242,7 @@ public class MultithreadedMapRunner<K1, V1, K2, V2>
         }
       } catch (IOException ex) {
         // If there is an IOException during the call it is set in an instance
-        // variable of the MultithreadedMapRunner from where it will be
+        // VARRRRRRRRiable of the MultithreadedMapRunner from where it will be
         // rethrown.
         synchronized (MultithreadedMapRunner.this) {
           if (MultithreadedMapRunner.this.ioException == null) {
@@ -251,7 +251,7 @@ public class MultithreadedMapRunner<K1, V1, K2, V2>
         }
       } catch (RuntimeException ex) {
         // If there is a RuntimeException during the call it is set in an
-        // instance variable of the MultithreadedMapRunner from where it will be
+        // instance VARRRRRRRRiable of the MultithreadedMapRunner from where it will be
         // rethrown.
         synchronized (MultithreadedMapRunner.this) {
           if (MultithreadedMapRunner.this.runtimeException == null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/NLineInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/NLineInputFormat.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.mapred.Reporter;
  * (one set per line) as input in a control file 
  * (which is the input path to the map-reduce application,
  * where as the input dataset is specified 
- * via a config variable in JobConf.).
+ * via a config VARRRRRRRRiable in JobConf.).
  * 
  * The NLineInputFormat can be used in such applications, that splits 
  * the input file such that by default, one line is fed as

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/aggregate/ValueAggregatorJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/lib/aggregate/ValueAggregatorJob.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.util.GenericOptionsParser;
 /**
  * This is the main class for creating a map/reduce job using Aggregate
  * framework. The Aggregate is a specialization of map/reduce framework,
- * specilizing for performing various simple aggregations.
+ * specilizing for performing VARRRRRRRRious simple aggregations.
  * 
  * Generally speaking, in order to implement an application using Map/Reduce
  * model, the developer is to implement Map and Reduce functions (and possibly

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Application.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Application.java
@@ -92,7 +92,7 @@ class Application<K1 extends WritableComparable, V1 extends Writable,
               ) throws IOException, InterruptedException {
     serverSocket = new ServerSocket(0);
     Map<String, String> env = new HashMap<String,String>();
-    // add TMPDIR environment variable with the value of java.io.tmpdir
+    // add TMPDIR environment VARRRRRRRRiable with the value of java.io.tmpdir
     env.put("TMPDIR", System.getProperty("java.io.tmpdir"));
     env.put(Submitter.PORT, 
             Integer.toString(serverSocket.getLocalPort()));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Submitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/Submitter.java
@@ -77,9 +77,9 @@ public class Submitter extends Configured implements Tool {
   public static final String INTERPRETOR = 
     "mapreduce.pipes.executable.interpretor";
   public static final String IS_JAVA_MAP = "mapreduce.pipes.isjavamapper";
-  public static final String IS_JAVA_RR = "mapreduce.pipes.isjavarecordreader";
-  public static final String IS_JAVA_RW = "mapreduce.pipes.isjavarecordwriter";
-  public static final String IS_JAVA_REDUCE = "mapreduce.pipes.isjavareducer";
+  public static final String IS_JAVA_RR = "mapreduce.pipes.isjaVARRRRRRRRecordreader";
+  public static final String IS_JAVA_RW = "mapreduce.pipes.isjaVARRRRRRRRecordwriter";
+  public static final String IS_JAVA_REDUCE = "mapreduce.pipes.isjaVARRRRRRRReducer";
   public static final String PARTITIONER = "mapreduce.pipes.partitioner";
   public static final String INPUT_FORMAT = "mapreduce.pipes.inputformat";
   public static final String PORT = "mapreduce.pipes.command.port";
@@ -223,7 +223,7 @@ public class Submitter extends Configured implements Tool {
    * program under the debugger. You probably also want to set 
    * JobConf.setKeepFailedTaskFiles(true) to keep the entire directory from
    * being deleted.
-   * To run using the data file, set the environment variable 
+   * To run using the data file, set the environment VARRRRRRRRiable 
    * "mapreduce.pipes.commandfile" to point to the file.
    * @param conf the configuration to check
    * @return will the framework save the command file?
@@ -402,7 +402,7 @@ public class Submitter extends Configured implements Tool {
     cli.addOption("jar", false, "job jar file", "path");
     cli.addOption("inputformat", false, "java classname of InputFormat", 
                   "class");
-    //cli.addArgument("javareader", false, "is the RecordReader in Java");
+    //cli.addArgument("jaVARRRRRRRReader", false, "is the RecordReader in Java");
     cli.addOption("map", false, "java classname of Mapper", "class");
     cli.addOption("partitioner", false, "java classname of Partitioner", 
                   "class");
@@ -438,7 +438,7 @@ public class Submitter extends Configured implements Tool {
         job.setInputFormat(getClass(results, "inputformat", job,
                                      InputFormat.class));
       }
-      if (results.hasOption("javareader")) {
+      if (results.hasOption("jaVARRRRRRRReader")) {
         setIsJavaRecordReader(job, true);
       }
       if (results.hasOption("map")) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/Job.java
@@ -59,7 +59,7 @@ import org.apache.hadoop.util.StringUtils;
  * IllegalStateException. </p>
  * 
  * <p>
- * Normally the user creates the application, describes various facets of the
+ * Normally the user creates the application, describes VARRRRRRRRious facets of the
  * job via {@link Job} and then submits the job and monitor its progress.</p>
  * 
  * <p>Here is an example on how to submit a job:</p>
@@ -68,7 +68,7 @@ import org.apache.hadoop.util.StringUtils;
  *     Job job = new Job(new Configuration());
  *     job.setJarByClass(MyJob.class);
  *     
- *     // Specify various job-specific parameters     
+ *     // Specify VARRRRRRRRious job-specific parameters     
  *     job.setJobName("myjob");
  *     
  *     job.setInputPath(new Path("in"));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobID.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/JobID.java
@@ -50,7 +50,7 @@ public class JobID extends org.apache.hadoop.mapred.ID
                    implements Comparable<ID> {
   protected static final String JOB = "job";
   
-  // Jobid regex for various tools and framework components
+  // Jobid regex for VARRRRRRRRious tools and framework components
   public static final String JOBID_REGEX = 
     JOB + SEPARATOR + "[0-9]+" + SEPARATOR + "[0-9]+";
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/MRJobConfig.java
@@ -446,7 +446,7 @@ public interface MRJobConfig {
 
   public static final String HADOOP_WORK_DIR = "HADOOP_WORK_DIR";
 
-  // Environment variables used by Pipes. (TODO: these
+  // Environment VARRRRRRRRiables used by Pipes. (TODO: these
   // do not appear to be used by current pipes source code!)
   public static final String STDOUT_LOGFILE_ENV = "STDOUT_LOGFILE_ENV";
   public static final String STDERR_LOGFILE_ENV = "STDERR_LOGFILE_ENV";

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/filecache/DistributedCache.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/filecache/DistributedCache.java
@@ -413,7 +413,7 @@ public class DistributedCache {
    * This method checks if there is a conflict in the fragment names 
    * of the uris. Also makes sure that each uri has a fragment. It 
    * is only to be called if you want to create symlinks for 
-   * the various archives and files.  May be used by user code.
+   * the VARRRRRRRRious archives and files.  May be used by user code.
    * @param uriFiles The uri array of urifiles
    * @param uriArchives the uri array of uri archives
    */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/MapAttemptFinishedEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/MapAttemptFinishedEvent.java
@@ -48,8 +48,8 @@ public class MapAttemptFinishedEvent  implements HistoryEvent {
    * @param rackName Name of the rack where the map executed
    * @param state State string for the attempt
    * @param counters Counters for the attempt
-   * @param allSplits the "splits", or a pixelated graph of various
-   *        measurable worker node state variables against progress.
+   * @param allSplits the "splits", or a pixelated graph of VARRRRRRRRious
+   *        measurable worker node state VARRRRRRRRiables against progress.
    *        Currently there are four; wallclock time, CPU time,
    *        virtual memory and physical memory. 
    *

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/ReduceAttemptFinishedEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/ReduceAttemptFinishedEvent.java
@@ -50,8 +50,8 @@ public class ReduceAttemptFinishedEvent  implements HistoryEvent {
    * @param rackName Name of the rack where the attempt executed
    * @param state State of the attempt
    * @param counters Counters for the attempt
-   * @param allSplits the "splits", or a pixelated graph of various
-   *        measurable worker node state variables against progress.
+   * @param allSplits the "splits", or a pixelated graph of VARRRRRRRRious
+   *        measurable worker node state VARRRRRRRRiables against progress.
    *        Currently there are four; wallclock time, CPU time,
    *        virtual memory and physical memory.  
    */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskAttemptUnsuccessfulCompletionEvent.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/jobhistory/TaskAttemptUnsuccessfulCompletionEvent.java
@@ -48,8 +48,8 @@ public class TaskAttemptUnsuccessfulCompletionEvent implements HistoryEvent {
    * @param hostname Name of the host where the attempt executed
    * @param port rpc port for for the tracker
    * @param error Error string
-   * @param allSplits the "splits", or a pixelated graph of various
-   *        measurable worker node state variables against progress.
+   * @param allSplits the "splits", or a pixelated graph of VARRRRRRRRious
+   *        measurable worker node state VARRRRRRRRiables against progress.
    *        Currently there are four; wallclock time, CPU time,
    *        virtual memory and physical memory.  
    */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/aggregate/ValueAggregatorJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/aggregate/ValueAggregatorJob.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.util.GenericOptionsParser;
 /**
  * This is the main class for creating a map/reduce job using Aggregate
  * framework. The Aggregate is a specialization of map/reduce framework,
- * specializing for performing various simple aggregations.
+ * specializing for performing VARRRRRRRRious simple aggregations.
  * 
  * Generally speaking, in order to implement an application using Map/Reduce
  * model, the developer is to implement Map and Reduce functions (and possibly

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/CombineFileRecordReader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/CombineFileRecordReader.java
@@ -147,7 +147,7 @@ public class CombineFileRecordReader<K, V> extends RecordReader<K, V> {
     // get a record reader for the idx-th chunk
     try {
       Configuration conf = context.getConfiguration();
-      // setup some helper config variables.
+      // setup some helper config VARRRRRRRRiables.
       conf.set(MRJobConfig.MAP_INPUT_FILE, split.getPath(idx).toString());
       conf.setLong(MRJobConfig.MAP_INPUT_START, split.getOffset(idx));
       conf.setLong(MRJobConfig.MAP_INPUT_PATH, split.getLength(idx));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/NLineInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/NLineInputFormat.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.util.LineReader;
  * (one set per line) as input in a control file 
  * (which is the input path to the map-reduce application,
  * where as the input dataset is specified 
- * via a config variable in JobConf.).
+ * via a config VARRRRRRRRiable in JobConf.).
  * 
  * The NLineInputFormat can be used in such applications, that splits 
  * the input file such that by default, one line is fed as

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/util/ProcfsBasedProcessTree.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/util/ProcfsBasedProcessTree.java
@@ -87,7 +87,7 @@ public class ProcfsBasedProcessTree extends ProcessTree {
     }
   }
 
-  // to enable testing, using this variable which can be configured
+  // to enable testing, using this VARRRRRRRRiable which can be configured
   // to a test directory.
   private String procfsDir;
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsConfPage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsConfPage.java
@@ -74,7 +74,7 @@ public class HsConfPage extends HsView {
    * by column.
    */
   private String confPostTableInit() {
-    return "var confInitVals = new Array();\n" +
+    return "VARRRRRRRR confInitVals = new Array();\n" +
     "$('tfoot input').keyup( function () \n{"+
     "  confDataTable.fnFilter( this.value, $('tfoot input').index(this) );\n"+
     "} );\n"+

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsController.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsController.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.yarn.webapp.log.AggregatedLogsPage;
 import com.google.inject.Inject;
 
 /**
- * This class renders the various pages that the History Server WebApp supports
+ * This class renders the VARRRRRRRRious pages that the History Server WebApp supports
  */
 public class HsController extends AppController {
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsJobBlock.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsJobBlock.java
@@ -229,7 +229,7 @@ public class HsJobBlock extends HtmlBlock {
   }
 
   /**
-   * Go through a job and update the member variables with counts for
+   * Go through a job and update the member VARRRRRRRRiables with counts for
    * information to output in the page.
    * @param job the job to get counts for.
    */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsTaskPage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsTaskPage.java
@@ -306,7 +306,7 @@ public class HsTaskPage extends HsView {
   }
   
   private String attemptsPostTableInit() {
-    return "var asInitVals = new Array();\n" +
+    return "VARRRRRRRR asInitVals = new Array();\n" +
            "$('tfoot input').keyup( function () \n{"+
            "  attemptsDataTable.fnFilter( this.value, $('tfoot input').index(this) );\n"+
            "} );\n"+

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsTasksPage.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsTasksPage.java
@@ -84,7 +84,7 @@ public class HsTasksPage extends HsView {
   }
   
   private String jobsPostTableInit() {
-    return "var asInitVals = new Array();\n" +
+    return "VARRRRRRRR asInitVals = new Array();\n" +
            "$('tfoot input').keyup( function () \n{"+
            "  tasksDataTable.fnFilter( this.value, $('tfoot input').index(this) );\n"+
            "} );\n"+

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsView.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-hs/src/main/java/org/apache/hadoop/mapreduce/v2/hs/webapp/HsView.java
@@ -104,7 +104,7 @@ public class HsView extends TwoColumnLayout {
    *  been initialized. This code adds in per field filtering.
    */
   private String jobsPostTableInit() {
-    return "var asInitVals = new Array();\n" +
+    return "VARRRRRRRR asInitVals = new Array();\n" +
     		   "$('tfoot input').keyup( function () \n{"+
            "  jobsDataTable.fnFilter( this.value, $('tfoot input').index(this) );\n"+
            "} );\n"+

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/main/java/org/apache/hadoop/mapred/YARNRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/main/java/org/apache/hadoop/mapred/YARNRunner.java
@@ -325,32 +325,32 @@ public class YARNRunner implements ClientProtocol {
     }
 
     // Setup the command to run the AM
-    List<String> vargs = new ArrayList<String>(8);
-    vargs.add(Environment.JAVA_HOME.$() + "/bin/java");
+    List<String> VARRRRRRRRgs = new ArrayList<String>(8);
+    VARRRRRRRRgs.add(Environment.JAVA_HOME.$() + "/bin/java");
 
     // TODO: why do we use 'conf' some places and 'jobConf' others?
     long logSize = TaskLog.getTaskLogLength(new JobConf(conf));
     String logLevel = jobConf.get(
         MRJobConfig.MR_AM_LOG_LEVEL, MRJobConfig.DEFAULT_MR_AM_LOG_LEVEL);
-    MRApps.addLog4jSystemProperties(logLevel, logSize, vargs);
+    MRApps.addLog4jSystemProperties(logLevel, logSize, VARRRRRRRRgs);
 
-    vargs.add(conf.get(MRJobConfig.MR_AM_COMMAND_OPTS,
+    VARRRRRRRRgs.add(conf.get(MRJobConfig.MR_AM_COMMAND_OPTS,
         MRJobConfig.DEFAULT_MR_AM_COMMAND_OPTS));
 
-    vargs.add(MRJobConfig.APPLICATION_MASTER_CLASS);
-    vargs.add("1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR +
+    VARRRRRRRRgs.add(MRJobConfig.APPLICATION_MASTER_CLASS);
+    VARRRRRRRRgs.add("1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR +
         Path.SEPARATOR + ApplicationConstants.STDOUT);
-    vargs.add("2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR +
+    VARRRRRRRRgs.add("2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR +
         Path.SEPARATOR + ApplicationConstants.STDERR);
 
 
-    Vector<String> vargsFinal = new Vector<String>(8);
+    Vector<String> VARRRRRRRRgsFinal = new Vector<String>(8);
     // Final commmand
     StringBuilder mergedCommand = new StringBuilder();
-    for (CharSequence str : vargs) {
+    for (CharSequence str : VARRRRRRRRgs) {
       mergedCommand.append(str).append(" ");
     }
-    vargsFinal.add(mergedCommand.toString());
+    VARRRRRRRRgsFinal.add(mergedCommand.toString());
 
     LOG.debug("Command to launch container for ApplicationMaster is : "
         + mergedCommand);
@@ -375,7 +375,7 @@ public class YARNRunner implements ClientProtocol {
     ContainerLaunchContext amContainer = BuilderUtils
         .newContainerLaunchContext(null, UserGroupInformation
             .getCurrentUser().getShortUserName(), capability, localResources,
-            environment, vargsFinal, null, securityTokens, acls);
+            environment, VARRRRRRRRgsFinal, null, securityTokens, acls);
 
     // Set up the ApplicationSubmissionContext
     ApplicationSubmissionContext appContext =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/RandomTextWriterJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/RandomTextWriterJob.java
@@ -694,7 +694,7 @@ public class RandomTextWriterJob extends Configured implements Tool {
       "ungouged", "floatability",
       "Mesua", "fetlocked",
       "chordacentrum", "sedentariness",
-      "various", "laubanite",
+      "VARRRRRRRRious", "laubanite",
       "nectopod", "zenick",
       "sequentially", "analgic",
       "biodynamics", "posttraumatic",

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTaskCommit.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTaskCommit.java
@@ -176,7 +176,7 @@ public class TestTaskCommit extends HadoopTestCase {
    * UmbilicalProtocol's implementation that fails if the commit.
    * protocol is played.
    * 
-   * The test mocks the various steps in a failed task's 
+   * The test mocks the VARRRRRRRRious steps in a failed task's 
    * life-cycle using a special OutputCommitter and UmbilicalProtocol
    * implementation.
    * 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/JobControlTestUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/JobControlTestUtils.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.mapred.Reducer;
 import org.apache.hadoop.mapred.Reporter;
 
 /**
- * Utility methods used in various Job Control unit tests.
+ * Utility methods used in VARRRRRRRRious Job Control unit tests.
  */
 public class JobControlTestUtils {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/MapReduceTestUtil.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/MapReduceTestUtil.java
@@ -57,7 +57,7 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.hadoop.util.ReflectionUtils;
 
 /**
- * Utility methods used in various Job Control unit tests.
+ * Utility methods used in VARRRRRRRRious Job Control unit tests.
  */
 public class MapReduceTestUtil {
   public static final Log LOG = 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/RandomTextWriter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/RandomTextWriter.java
@@ -733,7 +733,7 @@ public class RandomTextWriter extends Configured implements Tool {
                                    "ungouged", "floatability",
                                    "Mesua", "fetlocked",
                                    "chordacentrum", "sedentariness",
-                                   "various", "laubanite",
+                                   "VARRRRRRRRious", "laubanite",
                                    "nectopod", "zenick",
                                    "sequentially", "analgic",
                                    "biodynamics", "posttraumatic",

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/OneSidedPentomino.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/dancing/OneSidedPentomino.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.examples.dancing;
 
 /**
  * Of the "normal" 12 pentominos, 6 of them have distinct shapes when flipped.
- * This class includes both variants of the "flippable" shapes and the
+ * This class includes both VARRRRRRRRiants of the "flippable" shapes and the
  * unflippable shapes for a total of 18 pieces. Clearly, the boards must have
  * 18*5=90 boxes to hold all of the solutions.
  */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/Util.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-examples/src/main/java/org/apache/hadoop/examples/pi/Util.java
@@ -138,12 +138,12 @@ public class Util {
     return n + b.toString();    
   }
 
-  /** Parse a variable. */  
+  /** Parse a VARRRRRRRRiable. */  
   public static long parseLongVariable(final String name, final String s) {
     return string2long(parseStringVariable(name, s));
   }
 
-  /** Parse a variable. */  
+  /** Parse a VARRRRRRRRiable. */  
   public static String parseStringVariable(final String name, final String s) {
     if (!s.startsWith(name + '='))
       throw new IllegalArgumentException("!s.startsWith(name + '='), name="

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/ApplicationConstants.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/ApplicationConstants.java
@@ -38,31 +38,31 @@ public interface ApplicationConstants {
     "AppClientTokenEnv";
   
   /**
-   * The environment variable for CONTAINER_ID. Set in AppMaster environment
+   * The environment VARRRRRRRRiable for CONTAINER_ID. Set in AppMaster environment
    * only
    */
   public static final String AM_CONTAINER_ID_ENV = "AM_CONTAINER_ID";
 
   /**
-   * The environment variable for the NM_HOST. Set in the AppMaster environment
+   * The environment VARRRRRRRRiable for the NM_HOST. Set in the AppMaster environment
    * only
    */
   public static final String NM_HOST_ENV = "NM_HOST";
   
   /**
-   * The environment variable for the NM_PORT. Set in the AppMaster environment
+   * The environment VARRRRRRRRiable for the NM_PORT. Set in the AppMaster environment
    * only
    */
   public static final String NM_PORT_ENV = "NM_PORT";
   
   /**
-   * The environment variable for the NM_HTTP_PORT. Set in the AppMaster environment
+   * The environment VARRRRRRRRiable for the NM_HTTP_PORT. Set in the AppMaster environment
    * only
    */
   public static final String NM_HTTP_PORT_ENV = "NM_HTTP_PORT";
   
   /**
-   * The environment variable for APP_SUBMIT_TIME. Set in AppMaster environment
+   * The environment VARRRRRRRRiable for APP_SUBMIT_TIME. Set in AppMaster environment
    * only
    */
   public static final String APP_SUBMIT_TIME_ENV = "APP_SUBMIT_TIME_ENV";
@@ -73,7 +73,7 @@ public interface ApplicationConstants {
   public static final String LOCAL_DIR_ENV = "YARN_LOCAL_DIRS";
 
   /**
-   * The environmental variable for APPLICATION_WEB_PROXY_BASE. Set in 
+   * The environmental VARRRRRRRRiable for APPLICATION_WEB_PROXY_BASE. Set in 
    * ApplicationMaster's environment only. This states that for all non-relative
    * web URLs in the app masters web UI what base should they have.
    */
@@ -103,7 +103,7 @@ public interface ApplicationConstants {
   /**
    * Environment for Applications.
    * 
-   * Some of the environment variables for applications are <em>final</em> 
+   * Some of the environment VARRRRRRRRiables for applications are <em>final</em> 
    * i.e. they cannot be modified by the applications.
    */
   public enum Environment {
@@ -182,21 +182,21 @@ public interface ApplicationConstants {
      */
     YARN_HOME("YARN_HOME");
 
-    private final String variable;
-    private Environment(String variable) {
-      this.variable = variable;
+    private final String VARRRRRRRRiable;
+    private Environment(String VARRRRRRRRiable) {
+      this.VARRRRRRRRiable = VARRRRRRRRiable;
     }
     
     public String key() {
-      return variable;
+      return VARRRRRRRRiable;
     }
     
     public String toString() {
-      return variable;
+      return VARRRRRRRRiable;
     }
     
     public String $() {
-      return "$" + variable;
+      return "$" + VARRRRRRRRiable;
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ApplicationResourceUsageReport.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ApplicationResourceUsageReport.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.classification.InterfaceStability.Stable;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
 
 /**
- * Contains various scheduling metrics to be reported by UI and CLI.
+ * Contains VARRRRRRRRious scheduling metrics to be reported by UI and CLI.
  */
 @Public
 @Stable

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ContainerLaunchContext.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ContainerLaunchContext.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.yarn.api.ContainerManager;
  *       as binaries, jar, shared-objects, side-files etc. 
  *     </li>
  *     <li>Optional, application-specific binary service data.</li>
- *     <li>Environment variables for the launched process.</li>
+ *     <li>Environment VARRRRRRRRiables for the launched process.</li>
  *     <li>Command to launch the container.</li>
  *   </ul>
  * </p>
@@ -153,17 +153,17 @@ public interface ContainerLaunchContext {
   void setServiceData(Map<String, ByteBuffer> serviceData);
 
   /**
-   * Get <em>environment variables</em> for the container.
-   * @return <em>environment variables</em> for the container
+   * Get <em>environment VARRRRRRRRiables</em> for the container.
+   * @return <em>environment VARRRRRRRRiables</em> for the container
    */
   @Public
   @Stable
   Map<String, String> getEnvironment();
     
   /**
-   * Add <em>environment variables</em> for the container. All pre-existing Map
+   * Add <em>environment VARRRRRRRRiables</em> for the container. All pre-existing Map
    * entries are cleared before adding the new Map
-   * @param environment <em>environment variables</em> for the container
+   * @param environment <em>environment VARRRRRRRRiables</em> for the container
    */
   @Public
   @Stable

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/FinalApplicationStatus.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/FinalApplicationStatus.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Stable;
 
 /**
- * Enumeration of various final states of an <code>Application</code>.
+ * Enumeration of VARRRRRRRRious final states of an <code>Application</code>.
  */
 @Public
 @Stable

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/QueueACL.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/QueueACL.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.yarn.api.ClientRMProtocol;
 
 /**
  * <p>
- * <code>QueueACL</code> enumerates the various ACLs for queues.
+ * <code>QueueACL</code> enumerates the VARRRRRRRRious ACLs for queues.
  * </p>
  * 
  * <p>

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ResourceRequest.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/ResourceRequest.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.yarn.api.AMRMProtocol;
 
 /**
  * <p><code>ResourceRequest</code> represents the request made by an
- * application to the <code>ResourceManager</code> to obtain various 
+ * application to the <code>ResourceManager</code> to obtain VARRRRRRRRious 
  * <code>Container</code> allocations.</p>
  * 
  * <p>It includes:

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/YarnApplicationState.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-api/src/main/java/org/apache/hadoop/yarn/api/records/YarnApplicationState.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Stable;
 
 /**
- * Ennumeration of various states of an <code>ApplicationMaster</code>.
+ * Ennumeration of VARRRRRRRRious states of an <code>ApplicationMaster</code>.
  */
 @Public
 @Stable

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/ApplicationMaster.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/ApplicationMaster.java
@@ -166,7 +166,7 @@ public class ApplicationMaster {
   private String shellCommand = ""; 
   // Args to be passed to the shell command
   private String shellArgs = "";
-  // Env variables to be setup for the shell command 
+  // Env VARRRRRRRRiables to be setup for the shell command 
   private Map<String, String> shellEnv = new HashMap<String, String>();
 
   // Location of shell script ( obtained from info set in env )
@@ -677,29 +677,29 @@ public class ApplicationMaster {
       ctx.setLocalResources(localResources);			
 
       // Set the necessary command to execute on the allocated container 
-      Vector<CharSequence> vargs = new Vector<CharSequence>(5);
+      Vector<CharSequence> VARRRRRRRRgs = new Vector<CharSequence>(5);
 
       // Set executable command 
-      vargs.add(shellCommand);
+      VARRRRRRRRgs.add(shellCommand);
       // Set shell script path 
       if (!shellScriptPath.isEmpty()) {
-        vargs.add(ExecShellStringPath);
+        VARRRRRRRRgs.add(ExecShellStringPath);
       }
 
       // Set args for the shell command if any			
-      vargs.add(shellArgs);
+      VARRRRRRRRgs.add(shellArgs);
       // Add log redirect params
       // TODO
       // We should redirect the output to hdfs instead of local logs 
       // so as to be able to look at the final output after the containers 
       // have been released. 
       // Could use a path suffixed with /AppId/AppAttempId/ContainerId/std[out|err] 
-      vargs.add("1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/stdout");
-      vargs.add("2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/stderr");
+      VARRRRRRRRgs.add("1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/stdout");
+      VARRRRRRRRgs.add("2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/stderr");
 
       // Get final commmand
       StringBuilder command = new StringBuilder();
-      for (CharSequence str : vargs) {
+      for (CharSequence str : VARRRRRRRRgs) {
         command.append(str).append(" ");
       }
 

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/Client.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/main/java/org/apache/hadoop/yarn/applications/distributedshell/Client.java
@@ -151,7 +151,7 @@ public class Client {
   private String shellScriptPath = ""; 
   // Args to be passed to the shell command
   private String shellArgs = "";
-  // Env variables to be setup for the shell command 
+  // Env VARRRRRRRRiables to be setup for the shell command 
   private Map<String, String> shellEnv = new HashMap<String, String>();
   // Shell Command Container priority 
   private int shellCmdPriority = 0;
@@ -489,7 +489,7 @@ public class Client {
     // Set the necessary security tokens as needed
     //amContainer.setContainerTokens(containerToken);
 
-    // Set the env variables to be setup in the env where the application master will be run
+    // Set the env VARRRRRRRRiables to be setup in the env where the application master will be run
     LOG.info("Set the environment for the application master");
     Map<String, String> env = new HashMap<String, String>();
 
@@ -526,36 +526,36 @@ public class Client {
     amContainer.setEnvironment(env);
 
     // Set the necessary command to execute the application master 
-    Vector<CharSequence> vargs = new Vector<CharSequence>(30);
+    Vector<CharSequence> VARRRRRRRRgs = new Vector<CharSequence>(30);
 
     // Set java executable command 
     LOG.info("Setting up app master command");
-    vargs.add("${JAVA_HOME}" + "/bin/java");
+    VARRRRRRRRgs.add("${JAVA_HOME}" + "/bin/java");
     // Set class name 
-    vargs.add(appMasterMainClass);
+    VARRRRRRRRgs.add(appMasterMainClass);
     // Set params for Application Master
-    vargs.add("--container_memory " + String.valueOf(containerMemory));
-    vargs.add("--num_containers " + String.valueOf(numContainers));
-    vargs.add("--priority " + String.valueOf(shellCmdPriority));
+    VARRRRRRRRgs.add("--container_memory " + String.valueOf(containerMemory));
+    VARRRRRRRRgs.add("--num_containers " + String.valueOf(numContainers));
+    VARRRRRRRRgs.add("--priority " + String.valueOf(shellCmdPriority));
     if (!shellCommand.isEmpty()) {
-      vargs.add("--shell_command " + shellCommand + "");
+      VARRRRRRRRgs.add("--shell_command " + shellCommand + "");
     }
     if (!shellArgs.isEmpty()) {
-      vargs.add("--shell_args " + shellArgs + "");
+      VARRRRRRRRgs.add("--shell_args " + shellArgs + "");
     }
     for (Map.Entry<String, String> entry : shellEnv.entrySet()) {
-      vargs.add("--shell_env " + entry.getKey() + "=" + entry.getValue());
+      VARRRRRRRRgs.add("--shell_env " + entry.getKey() + "=" + entry.getValue());
     }			
     if (debugFlag) {
-      vargs.add("--debug");
+      VARRRRRRRRgs.add("--debug");
     }
 
-    vargs.add("1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/AppMaster.stdout");
-    vargs.add("2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/AppMaster.stderr");
+    VARRRRRRRRgs.add("1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/AppMaster.stdout");
+    VARRRRRRRRgs.add("2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/AppMaster.stderr");
 
     // Get final commmand
     StringBuilder command = new StringBuilder();
-    for (CharSequence str : vargs) {
+    for (CharSequence str : VARRRRRRRRgs) {
       command.append(str).append(" ");
     }
 

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/conf/YarnConfiguration.java
@@ -220,11 +220,11 @@ public class YarnConfiguration extends Configuration {
   /** Prefix for all node manager configs.*/
   public static final String NM_PREFIX = "yarn.nodemanager.";
 
-  /** Environment variables that will be sent to containers.*/
+  /** Environment VARRRRRRRRiables that will be sent to containers.*/
   public static final String NM_ADMIN_USER_ENV = NM_PREFIX + "admin-env";
   public static final String DEFAULT_NM_ADMIN_USER_ENV = "MALLOC_ARENA_MAX=$MALLOC_ARENA_MAX";
 
-  /** Environment variables that containers may override rather than use NodeManager's default.*/
+  /** Environment VARRRRRRRRiables that containers may override rather than use NodeManager's default.*/
   public static final String NM_ENV_WHITELIST = NM_PREFIX + "env-whitelist";
   public static final String DEFAULT_NM_ENV_WHITELIST = "JAVA_HOME,HADOOP_COMMON_HOME,HADOOP_HDFS_HOME,HADOOP_CONF_DIR,YARN_HOME";
   

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Apps.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/Apps.java
@@ -80,7 +80,7 @@ public class Apps {
             // the env key is present in the tt's env
             value = parts[1].replace("$" + parts[0], value);
           } else {
-            // check for simple variable substitution
+            // check for simple VARRRRRRRRiable substitution
             // for e.g. ROOT=$HOME
             String envValue = System.getenv(parts[1].substring(1));
             if (envValue != null) {
@@ -102,13 +102,13 @@ public class Apps {
 
   public static void addToEnvironment(
       Map<String, String> environment,
-      String variable, String value) {
-    String val = environment.get(variable);
+      String VARRRRRRRRiable, String value) {
+    String val = environment.get(VARRRRRRRRiable);
     if (val == null) {
       val = value;
     } else {
       val = val + SYSTEM_PATH_SEPARATOR + value;
     }
-    environment.put(variable, val);
+    environment.put(VARRRRRRRRiable, val);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/BuilderUtils.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/BuilderUtils.java
@@ -53,7 +53,7 @@ import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.security.ContainerTokenIdentifier;
 
 /**
- * Builder utilities to construct various objects.
+ * Builder utilities to construct VARRRRRRRRious objects.
  *
  */
 public class BuilderUtils {

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/FSDownload.java
@@ -167,7 +167,7 @@ public class FSDownload implements Callable<Path> {
       try {
         files.delete(dst_work, true);
       } catch (FileNotFoundException ignore) { }
-      // clear ref to internal var
+      // clear ref to internal VARRRRRRRR
       rand = null;
       conf = null;
       resource = null;

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/util/ProcfsBasedProcessTree.java
@@ -87,7 +87,7 @@ public class ProcfsBasedProcessTree {
     }
   }
 
-  // to enable testing, using this variable which can be configured
+  // to enable testing, using this VARRRRRRRRiable which can be configured
   // to a test directory.
   private String procfsDir;
   

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/Dispatcher.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/Dispatcher.java
@@ -41,7 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The servlet that dispatch request to various controllers
+ * The servlet that dispatch request to VARRRRRRRRious controllers
  * according to the user defined routes in the router.
  */
 @Singleton

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/hamlet/Hamlet.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/hamlet/Hamlet.java
@@ -1197,19 +1197,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<TD<T>> var() {
+    public VAR<TD<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public TD<T> var(String cdata) {
-      return var()._(cdata)._();
+    public TD<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public TD<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public TD<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -2000,19 +2000,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<TH<T>> var() {
+    public VAR<TH<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public TH<T> var(String cdata) {
-      return var()._(cdata)._();
+    public TH<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public TH<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public TH<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -3250,19 +3250,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<CAPTION<T>> var() {
+    public VAR<CAPTION<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public CAPTION<T> var(String cdata) {
-      return var()._(cdata)._();
+    public CAPTION<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public CAPTION<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public CAPTION<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -4154,19 +4154,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<BUTTON<T>> var() {
+    public VAR<BUTTON<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public BUTTON<T> var(String cdata) {
-      return var()._(cdata)._();
+    public BUTTON<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public BUTTON<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public BUTTON<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -4714,19 +4714,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<LEGEND<T>> var() {
+    public VAR<LEGEND<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public LEGEND<T> var(String cdata) {
-      return var()._(cdata)._();
+    public LEGEND<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public LEGEND<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public LEGEND<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -5504,19 +5504,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<FIELDSET<T>> var() {
+    public VAR<FIELDSET<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public FIELDSET<T> var(String cdata) {
-      return var()._(cdata)._();
+    public FIELDSET<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public FIELDSET<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public FIELDSET<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -6901,19 +6901,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<LABEL<T>> var() {
+    public VAR<LABEL<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public LABEL<T> var(String cdata) {
-      return var()._(cdata)._();
+    public LABEL<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public LABEL<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public LABEL<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -8054,19 +8054,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<LI<T>> var() {
+    public VAR<LI<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public LI<T> var(String cdata) {
-      return var()._(cdata)._();
+    public LI<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public LI<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public LI<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -9062,19 +9062,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<DD<T>> var() {
+    public VAR<DD<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public DD<T> var(String cdata) {
-      return var()._(cdata)._();
+    public DD<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public DD<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public DD<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -9606,19 +9606,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<DT<T>> var() {
+    public VAR<DT<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public DT<T> var(String cdata) {
-      return var()._(cdata)._();
+    public DT<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public DT<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public DT<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -10527,19 +10527,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<DEL<T>> var() {
+    public VAR<DEL<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public DEL<T> var(String cdata) {
-      return var()._(cdata)._();
+    public DEL<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public DEL<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public DEL<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -11318,19 +11318,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<INS<T>> var() {
+    public VAR<INS<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public INS<T> var(String cdata) {
-      return var()._(cdata)._();
+    public INS<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public INS<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public INS<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -12222,19 +12222,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<Q<T>> var() {
+    public VAR<Q<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public Q<T> var(String cdata) {
-      return var()._(cdata)._();
+    public Q<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public Q<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public Q<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -12750,19 +12750,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<PRE<T>> var() {
+    public VAR<PRE<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public PRE<T> var(String cdata) {
-      return var()._(cdata)._();
+    public PRE<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public PRE<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public PRE<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -13240,19 +13240,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<H6<T>> var() {
+    public VAR<H6<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public H6<T> var(String cdata) {
-      return var()._(cdata)._();
+    public H6<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public H6<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public H6<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -13784,19 +13784,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<H5<T>> var() {
+    public VAR<H5<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public H5<T> var(String cdata) {
-      return var()._(cdata)._();
+    public H5<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public H5<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public H5<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -14328,19 +14328,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<H4<T>> var() {
+    public VAR<H4<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public H4<T> var(String cdata) {
-      return var()._(cdata)._();
+    public H4<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public H4<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public H4<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -14872,19 +14872,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<H3<T>> var() {
+    public VAR<H3<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public H3<T> var(String cdata) {
-      return var()._(cdata)._();
+    public H3<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public H3<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public H3<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -15416,19 +15416,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<H2<T>> var() {
+    public VAR<H2<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public H2<T> var(String cdata) {
-      return var()._(cdata)._();
+    public H2<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public H2<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public H2<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -15960,19 +15960,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<H1<T>> var() {
+    public VAR<H1<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public H1<T> var(String cdata) {
-      return var()._(cdata)._();
+    public H1<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public H1<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public H1<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -16504,19 +16504,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<P<T>> var() {
+    public VAR<P<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public P<T> var(String cdata) {
-      return var()._(cdata)._();
+    public P<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public P<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public P<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -17474,19 +17474,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<OBJECT<T>> var() {
+    public VAR<OBJECT<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public OBJECT<T> var(String cdata) {
-      return var()._(cdata)._();
+    public OBJECT<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public OBJECT<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public OBJECT<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -18876,19 +18876,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<A<T>> var() {
+    public VAR<A<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public A<T> var(String cdata) {
-      return var()._(cdata)._();
+    public A<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public A<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public A<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -19634,19 +19634,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<DIV<T>> var() {
+    public VAR<DIV<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public DIV<T> var(String cdata) {
-      return var()._(cdata)._();
+    public DIV<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public DIV<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public DIV<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -20178,19 +20178,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<ADDRESS<T>> var() {
+    public VAR<ADDRESS<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public ADDRESS<T> var(String cdata) {
-      return var()._(cdata)._();
+    public ADDRESS<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public ADDRESS<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public ADDRESS<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -21104,19 +21104,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<BDO<T>> var() {
+    public VAR<BDO<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public BDO<T> var(String cdata) {
-      return var()._(cdata)._();
+    public BDO<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public BDO<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public BDO<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -21648,19 +21648,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<SPAN<T>> var() {
+    public VAR<SPAN<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public SPAN<T> var(String cdata) {
-      return var()._(cdata)._();
+    public SPAN<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public SPAN<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public SPAN<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -22192,19 +22192,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<SUP<T>> var() {
+    public VAR<SUP<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public SUP<T> var(String cdata) {
-      return var()._(cdata)._();
+    public SUP<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public SUP<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public SUP<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -22736,19 +22736,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<SUB<T>> var() {
+    public VAR<SUB<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public SUB<T> var(String cdata) {
-      return var()._(cdata)._();
+    public SUB<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public SUB<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public SUB<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -23280,19 +23280,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<ACRONYM<T>> var() {
+    public VAR<ACRONYM<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public ACRONYM<T> var(String cdata) {
-      return var()._(cdata)._();
+    public ACRONYM<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public ACRONYM<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public ACRONYM<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -23824,19 +23824,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<ABBR<T>> var() {
+    public VAR<ABBR<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public ABBR<T> var(String cdata) {
-      return var()._(cdata)._();
+    public ABBR<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public ABBR<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public ABBR<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -24368,19 +24368,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<CITE<T>> var() {
+    public VAR<CITE<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public CITE<T> var(String cdata) {
-      return var()._(cdata)._();
+    public CITE<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public CITE<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public CITE<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -24912,19 +24912,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<VAR<T>> var() {
+    public VAR<VAR<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public VAR<T> var(String cdata) {
-      return var()._(cdata)._();
+    public VAR<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public VAR<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public VAR<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -25456,19 +25456,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<KBD<T>> var() {
+    public VAR<KBD<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public KBD<T> var(String cdata) {
-      return var()._(cdata)._();
+    public KBD<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public KBD<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public KBD<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -26000,19 +26000,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<SAMP<T>> var() {
+    public VAR<SAMP<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public SAMP<T> var(String cdata) {
-      return var()._(cdata)._();
+    public SAMP<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public SAMP<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public SAMP<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -26544,19 +26544,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<CODE<T>> var() {
+    public VAR<CODE<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public CODE<T> var(String cdata) {
-      return var()._(cdata)._();
+    public CODE<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public CODE<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public CODE<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -27088,19 +27088,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<DFN<T>> var() {
+    public VAR<DFN<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public DFN<T> var(String cdata) {
-      return var()._(cdata)._();
+    public DFN<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public DFN<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public DFN<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -27632,19 +27632,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<STRONG<T>> var() {
+    public VAR<STRONG<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public STRONG<T> var(String cdata) {
-      return var()._(cdata)._();
+    public STRONG<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public STRONG<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public STRONG<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -28176,19 +28176,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<EM<T>> var() {
+    public VAR<EM<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public EM<T> var(String cdata) {
-      return var()._(cdata)._();
+    public EM<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public EM<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public EM<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -28720,19 +28720,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<SMALL<T>> var() {
+    public VAR<SMALL<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public SMALL<T> var(String cdata) {
-      return var()._(cdata)._();
+    public SMALL<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public SMALL<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public SMALL<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -29264,19 +29264,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<B<T>> var() {
+    public VAR<B<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public B<T> var(String cdata) {
-      return var()._(cdata)._();
+    public B<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public B<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public B<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -29808,19 +29808,19 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
     }
 
     @Override
-    public VAR<I<T>> var() {
+    public VAR<I<T>> VARRRRRRRR() {
       closeAttrs();
-      return var_(this, true);
+      return VARRRRRRRR_(this, true);
     }
 
     @Override
-    public I<T> var(String cdata) {
-      return var()._(cdata)._();
+    public I<T> VARRRRRRRR(String cdata) {
+      return VARRRRRRRR()._(cdata)._();
     }
 
     @Override
-    public I<T> var(String selector, String cdata) {
-      return setSelector(var(), selector)._(cdata)._();
+    public I<T> VARRRRRRRR(String selector, String cdata) {
+      return setSelector(VARRRRRRRR(), selector)._(cdata)._();
     }
 
     @Override
@@ -30160,8 +30160,8 @@ public class Hamlet extends HamletImpl implements HamletSpec._Html {
   private <T extends _> KBD<T> kbd_(T e, boolean inline) {
     return new KBD<T>("kbd", e, opt(true, inline, false)); }
 
-  private <T extends _> VAR<T> var_(T e, boolean inline) {
-    return new VAR<T>("var", e, opt(true, inline, false)); }
+  private <T extends _> VAR<T> VARRRRRRRR_(T e, boolean inline) {
+    return new VAR<T>("VARRRRRRRR", e, opt(true, inline, false)); }
 
   private <T extends _> CITE<T> cite_(T e, boolean inline) {
     return new CITE<T>("cite", e, opt(true, inline, false)); }

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/hamlet/HamletSpec.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/hamlet/HamletSpec.java
@@ -901,25 +901,25 @@ public class HamletSpec {
     Phrase kbd(String selector, String cdata);
 
     /**
-     * Add a VAR (variable) element.
+     * Add a VAR (VARRRRRRRRiable) element.
      * @return a new VAR element builder
      */
-    VAR var();
+    VAR VARRRRRRRR();
 
     /**
-     * Add a VAR (variable) element.
+     * Add a VAR (VARRRRRRRRiable) element.
      * @param cdata the content
      * @return the current element builder
      */
-    Phrase var(String cdata);
+    Phrase VARRRRRRRR(String cdata);
 
     /**
-     * Add a VAR (variable) element.
+     * Add a VAR (VARRRRRRRRiable) element.
      * @param selector the css selector in the form of (#id)*(.class)*
      * @param cdata the content
      * @return the current element builder
      */
-    Phrase var(String selector, String cdata);
+    Phrase VARRRRRRRR(String selector, String cdata);
 
     /**
      * Add a CITE element.
@@ -2518,7 +2518,7 @@ public class HamletSpec {
    *
    */
   public interface TEXTAREA extends Attrs, PCData, _Child {
-    /** variable name for the text
+    /** VARRRRRRRRiable name for the text
      * @param cdata
      * @return the current element builder
      */

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/TwoColumnLayout.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/view/TwoColumnLayout.java
@@ -71,7 +71,7 @@ public class TwoColumnLayout extends HtmlPage {
 
   /**
    * Do what needs to be done before the header is rendered.  This usually
-   * involves setting page variables for Javascript and CSS rendering.
+   * involves setting page VARRRRRRRRiables for Javascript and CSS rendering.
    * @param html the html to use to render. 
    */
   protected void preHead(Page.HTML<_> html) {

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/ContainerLaunch.java
@@ -134,7 +134,7 @@ public class ContainerLaunch implements Callable<Integer> {
       launchContext.setCommands(newCmds);
 
       Map<String, String> environment = launchContext.getEnvironment();
-      // Make a copy of env to iterate & do variable expansion
+      // Make a copy of env to iterate & do VARRRRRRRRiable expansion
       for (Entry<String, String> entry : environment.entrySet()) {
         String value = entry.getValue();
         entry.setValue(
@@ -143,7 +143,7 @@ public class ContainerLaunch implements Callable<Integer> {
                 containerLogDir.toUri().getPath())
             );
       }
-      // /////////////////////////// End of variable expansion
+      // /////////////////////////// End of VARRRRRRRRiable expansion
 
       FileContext lfs = FileContext.getLocalFSFileContext();
 
@@ -464,23 +464,23 @@ public class ContainerLaunch implements Callable<Integer> {
   }
 
   private static void putEnvIfNotNull(
-      Map<String, String> environment, String variable, String value) {
+      Map<String, String> environment, String VARRRRRRRRiable, String value) {
     if (value != null) {
-      environment.put(variable, value);
+      environment.put(VARRRRRRRRiable, value);
     }
   }
   
   private static void putEnvIfAbsent(
-      Map<String, String> environment, String variable) {
-    if (environment.get(variable) == null) {
-      putEnvIfNotNull(environment, variable, System.getenv(variable));
+      Map<String, String> environment, String VARRRRRRRRiable) {
+    if (environment.get(VARRRRRRRRiable) == null) {
+      putEnvIfNotNull(environment, VARRRRRRRRiable, System.getenv(VARRRRRRRRiable));
     }
   }
   
   public void sanitizeEnv(Map<String, String> environment, 
       Path pwd, List<Path> appDirs) {
     /**
-     * Non-modifiable environment variables
+     * Non-modifiable environment VARRRRRRRRiables
      */
 
     putEnvIfNotNull(environment, Environment.USER.name(), container.getUser());
@@ -513,17 +513,17 @@ public class ContainerLaunch implements Callable<Integer> {
     }
 
     /**
-     * Modifiable environment variables
+     * Modifiable environment VARRRRRRRRiables
      */
     
-    // allow containers to override these variables
+    // allow containers to override these VARRRRRRRRiables
     String[] whitelist = conf.get(YarnConfiguration.NM_ENV_WHITELIST, YarnConfiguration.DEFAULT_NM_ENV_WHITELIST).split(",");
     
     for(String whitelistEnvVariable : whitelist) {
       putEnvIfAbsent(environment, whitelistEnvVariable.trim());
     }
 
-    // variables here will be forced in, even if the container has specified them.
+    // VARRRRRRRRiables here will be forced in, even if the container has specified them.
     Apps.setEnvFromInputString(
       environment,
       conf.get(

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestNMAuditLogger.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/TestNMAuditLogger.java
@@ -133,7 +133,7 @@ public class TestNMAuditLogger {
   }
 
   /**
-   * Test the AuditLog format for successful events with the various
+   * Test the AuditLog format for successful events with the VARRRRRRRRious
    * parameters.
    */
   private void testSuccessLogFormat(boolean checkIP) {
@@ -172,7 +172,7 @@ public class TestNMAuditLogger {
   }
 
   /**
-   * Test the AuditLog format for failure events with the various
+   * Test the AuditLog format for failure events with the VARRRRRRRRious
    * parameters.
    */
   private void testFailureLogFormat(boolean checkIP) {

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/test/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/launcher/TestContainerLaunch.java
@@ -154,7 +154,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
   }
 
   /**
-   * See if environment variable is forwarded using sanitizeEnv.
+   * See if environment VARRRRRRRRiable is forwarded using sanitizeEnv.
    * @throws Exception
    */
   @Test
@@ -170,7 +170,7 @@ public class TestContainerLaunch extends BaseContainerManagerTest {
     File scriptFile = new File(tmpDir, "scriptFile.sh");
     PrintWriter fileWriter = new PrintWriter(scriptFile);
     File processStartFile =
-        new File(tmpDir, "env_vars.txt").getAbsoluteFile();
+        new File(tmpDir, "env_VARRRRRRRRs.txt").getAbsoluteFile();
     fileWriter.write("\numask 0"); // So that start file is readable by the test
     fileWriter.write("\necho $" + Environment.MALLOC_ARENA_MAX.name() + " > " + processStartFile);
     fileWriter.write("\necho $$ >> " + processStartFile);

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMApp.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/rmapp/RMApp.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttempt;
 /**
  * The read interface to an Application in the ResourceManager. Take a
  * look at {@link RMAppImpl} for its implementation. This interface
- * exposes methods to access various updates in application status/report.
+ * exposes methods to access VARRRRRRRRious updates in application status/report.
  */
 public interface RMApp extends EventHandler<RMAppEvent> {
 

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/AppsBlock.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/AppsBlock.java
@@ -89,7 +89,7 @@ class AppsBlock extends HtmlBlock {
 
     if (list.rendering == Render.JS_ARRAY) {
       echo("<script type='text/javascript'>\n",
-           "var appsData=");
+           "VARRRRRRRR appsData=");
       list.toDataTableArrays(writer());
       echo("\n</script>\n");
     }

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/CapacitySchedulerPage.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/CapacitySchedulerPage.java
@@ -153,7 +153,7 @@ class CapacitySchedulerPage extends RmView {
           "    }",
           "  });",
           "  $('#cs').bind('select_node.jstree', function(e, data) {",
-          "    var q = $('.q', data.rslt.obj).first().text();",
+          "    VARRRRRRRR q = $('.q', data.rslt.obj).first().text();",
             "    if (q == 'root') q = '';",
           "    $('#apps').dataTable().fnFilter(q, 3);",
           "  });",

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/DefaultSchedulerPage.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/webapp/DefaultSchedulerPage.java
@@ -168,7 +168,7 @@ class DefaultSchedulerPage extends RmView {
           "    }",
           "  });",
           "  $('#cs').bind('select_node.jstree', function(e, data) {",
-          "    var q = $('.q', data.rslt.obj).first().text();",
+          "    VARRRRRRRR q = $('.q', data.rslt.obj).first().text();",
             "    if (q == 'root') q = '';",
           "    $('#apps').dataTable().fnFilter(q, 3);",
           "  });",

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestAppManager.java
@@ -239,7 +239,7 @@ public class TestAppManager{
     rmContext.getRMApps().clear();
     Assert.assertEquals("map isn't empty", 0, rmContext.getRMApps().size());
 
-    // / set with various finished states
+    // / set with VARRRRRRRRious finished states
     RMApp app = new MockRMApp(0, now - 20000, RMAppState.KILLED);
     rmContext.getRMApps().put(app.getApplicationId(), app);
     app = new MockRMApp(1, now - 200000, RMAppState.FAILED);

--- a/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMAuditLogger.java
+++ b/hadoop-mapreduce-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/test/java/org/apache/hadoop/yarn/server/resourcemanager/TestRMAuditLogger.java
@@ -139,7 +139,7 @@ public class TestRMAuditLogger {
   }
 
   /**
-   * Test the AuditLog format for successful events with the various
+   * Test the AuditLog format for successful events with the VARRRRRRRRious
    * parameters.
    */
   private void testSuccessLogFormat(boolean checkIP) {
@@ -185,7 +185,7 @@ public class TestRMAuditLogger {
   }
 
   /**
-   * Test the AuditLog format for failure events with the various
+   * Test the AuditLog format for failure events with the VARRRRRRRRious
    * parameters.
    */
   private void testFailureLogFormat(boolean checkIP) {

--- a/hadoop-mapreduce-project/src/contrib/block_forensics/client/BlockForensics.java
+++ b/hadoop-mapreduce-project/src/contrib/block_forensics/client/BlockForensics.java
@@ -104,7 +104,7 @@ public class BlockForensics {
            InterruptedException, IOException {
 
     if (System.getenv("HADOOP_PREFIX") == null) {
-      System.err.println("The environmental variable HADOOP_PREFIX is undefined");
+      System.err.println("The environmental VARRRRRRRRiable HADOOP_PREFIX is undefined");
       System.exit(1);
     }
 

--- a/hadoop-mapreduce-project/src/contrib/eclipse-plugin/src/java/org/apache/hadoop/eclipse/preferences/MapReducePreferencePage.java
+++ b/hadoop-mapreduce-project/src/contrib/eclipse-plugin/src/java/org/apache/hadoop/eclipse/preferences/MapReducePreferencePage.java
@@ -47,7 +47,7 @@ public class MapReducePreferencePage extends FieldEditorPreferencePage
 
   /**
    * Creates the field editors. Field editors are abstractions of the common
-   * GUI blocks needed to manipulate various types of preferences. Each field
+   * GUI blocks needed to manipulate VARRRRRRRRious types of preferences. Each field
    * editor knows how to save and restore itself.
    */
   @Override

--- a/hadoop-mapreduce-project/src/contrib/gridmix/src/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-mapreduce-project/src/contrib/gridmix/src/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -429,7 +429,7 @@ public class Gridmix extends Configured implements Tool {
         // scan input dir contents
         submitter.refreshFilePool();
 
-        // set up the needed things for emulation of various loads
+        // set up the needed things for emulation of VARRRRRRRRious loads
         int exitCode = setupEmulation(conf, traceIn, scratchDir, ioPath,
                                       generate);
         if (exitCode != 0) {
@@ -479,7 +479,7 @@ public class Gridmix extends Configured implements Tool {
 
   /**
    * Create gridmix output directory. Setup things for emulation of
-   * various loads, if needed.
+   * VARRRRRRRRious loads, if needed.
    * @param conf gridmix configuration
    * @param traceIn trace file path(if it is '-', then trace comes from the
    *                stream stdin)

--- a/hadoop-mapreduce-project/src/contrib/gridmix/src/java/org/apache/hadoop/mapred/gridmix/RandomTextDataGenerator.java
+++ b/hadoop-mapreduce-project/src/contrib/gridmix/src/java/org/apache/hadoop/mapred/gridmix/RandomTextDataGenerator.java
@@ -85,7 +85,7 @@ class RandomTextDataGenerator {
     words = new String[size];
     
     //TODO change the default with the actual stats
-    //TODO do u need varied sized words?
+    //TODO do u need VARRRRRRRRied sized words?
     for (int i = 0; i < size; ++i) {
       words[i] = 
         RandomStringUtils.random(wordSize, 0, 0, true, false, null, random);

--- a/hadoop-mapreduce-project/src/contrib/gridmix/src/java/org/apache/hadoop/mapred/gridmix/Summarizer.java
+++ b/hadoop-mapreduce-project/src/contrib/gridmix/src/java/org/apache/hadoop/mapred/gridmix/Summarizer.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.gridmix.GenerateData.DataStatistics;
 
 /**
- * Summarizes various aspects of a {@link Gridmix} run.
+ * Summarizes VARRRRRRRRious aspects of a {@link Gridmix} run.
  */
 class Summarizer {
   private ExecutionSummarizer executionSummarizer;

--- a/hadoop-mapreduce-project/src/contrib/gridmix/src/java/org/apache/hadoop/mapred/gridmix/emulators/resourceusage/ResourceUsageEmulatorPlugin.java
+++ b/hadoop-mapreduce-project/src/contrib/gridmix/src/java/org/apache/hadoop/mapred/gridmix/emulators/resourceusage/ResourceUsageEmulatorPlugin.java
@@ -45,7 +45,7 @@ import org.apache.hadoop.conf.Configuration;
 public interface ResourceUsageEmulatorPlugin extends Progressive {
   /**
    * Initialize the plugin. This might involve
-   *   - initializing the variables
+   *   - initializing the VARRRRRRRRiables
    *   - calibrating the plugin
    */
   void initialize(Configuration conf, ResourceUsageMetrics metrics, 

--- a/hadoop-mapreduce-project/src/contrib/gridmix/src/test/org/apache/hadoop/mapred/gridmix/TestGridmixSubmission.java
+++ b/hadoop-mapreduce-project/src/contrib/gridmix/src/test/org/apache/hadoop/mapred/gridmix/TestGridmixSubmission.java
@@ -255,7 +255,7 @@ public class TestGridmixSubmission {
 
             specInfo = spec.getTaskInfo(TaskType.REDUCE, i);
             // There is no reliable counter for reduce input bytes. The
-            // variable-length encoding of intermediate records and other noise
+            // VARRRRRRRRiable-length encoding of intermediate records and other noise
             // make this quantity difficult to estimate. The shuffle and spec
             // input bytes are included in debug output for reference, but are
             // not checked

--- a/hadoop-mapreduce-project/src/contrib/gridmix/src/test/system/org/apache/hadoop/mapred/gridmix/TestGridMixDataGeneration.java
+++ b/hadoop-mapreduce-project/src/contrib/gridmix/src/test/system/org/apache/hadoop/mapred/gridmix/TestGridMixDataGeneration.java
@@ -42,7 +42,7 @@ import org.junit.Assert;
 import java.io.IOException;
 
 /**
- * Verify the Gridmix data generation with various submission policies and 
+ * Verify the Gridmix data generation with VARRRRRRRRious submission policies and 
  * user resolver modes.
  */
 public class TestGridMixDataGeneration {

--- a/hadoop-mapreduce-project/src/contrib/vaidya/src/java/org/apache/hadoop/vaidya/postexdiagnosis/tests/BalancedReducePartitioning.java
+++ b/hadoop-mapreduce-project/src/contrib/vaidya/src/java/org/apache/hadoop/vaidya/postexdiagnosis/tests/BalancedReducePartitioning.java
@@ -50,7 +50,7 @@ public class BalancedReducePartitioning extends DiagnosticTest {
   @Override
   public double evaluate(JobStatistics jobExecutionStats) {
     
-    /* Set the global job variable */
+    /* Set the global job VARRRRRRRRiable */
     this._job = jobExecutionStats;
 
     /* If Map only job then impact is zero */

--- a/hadoop-mapreduce-project/src/contrib/vertica/src/java/org/apache/hadoop/vertica/VerticaOutputFormat.java
+++ b/hadoop-mapreduce-project/src/contrib/vertica/src/java/org/apache/hadoop/vertica/VerticaOutputFormat.java
@@ -74,7 +74,7 @@ public class VerticaOutputFormat extends OutputFormat<Text, VerticaRecord> {
    * @param tableName
    * @param dropTable
    * @param tableDef
-   *          list of column definitions such as "foo int", "bar varchar(10)"
+   *          list of column definitions such as "foo int", "bar VARRRRRRRRchar(10)"
    */
   public static void setOutput(Job job, String tableName, boolean dropTable,
       String... tableDef) {

--- a/hadoop-mapreduce-project/src/contrib/vertica/src/java/org/apache/hadoop/vertica/VerticaRecord.java
+++ b/hadoop-mapreduce-project/src/contrib/vertica/src/java/org/apache/hadoop/vertica/VerticaRecord.java
@@ -346,7 +346,7 @@ public class VerticaRecord implements Writable {
       Object obj = values.get(i);
       Integer type = types.get(i);
 
-      // switch statement uses fall through to handle type variations
+      // switch statement uses fall through to handle type VARRRRRRRRiations
       // e.g. type specified as BIGINT but passed in as Integer
       switch (type) {
       case Types.NULL:

--- a/hadoop-mapreduce-project/src/contrib/vertica/src/test/org/apache/hadoop/vertica/TestExample.java
+++ b/hadoop-mapreduce-project/src/contrib/vertica/src/test/org/apache/hadoop/vertica/TestExample.java
@@ -107,8 +107,8 @@ public class TestExample extends VerticaTestCase implements Tool {
     job.setMapperClass(Map.class);
     job.setReducerClass(Reduce.class);
     VerticaOutputFormat.setOutput(job, "mrtarget", true, "a int", "b boolean",
-        "c char(1)", "d date", "f float", "t timestamp", "v varchar",
-        "z varbinary");
+        "c char(1)", "d date", "f float", "t timestamp", "v VARRRRRRRRchar",
+        "z VARRRRRRRRbinary");
     VerticaConfiguration.configureVertica(conf,
         new String[] { AllTests.getHostname() }, AllTests.getDatabase(),
         AllTests.getUsername(), AllTests.getPassword());

--- a/hadoop-mapreduce-project/src/contrib/vertica/src/test/org/apache/hadoop/vertica/TestVertica.java
+++ b/hadoop-mapreduce-project/src/contrib/vertica/src/test/org/apache/hadoop/vertica/TestVertica.java
@@ -352,12 +352,12 @@ public class TestVertica extends VerticaTestCase {
     }
 
     // TODO: test create schema
-    // TODO: test writable variants of data types
+    // TODO: test writable VARRRRRRRRiants of data types
     VerticaOutputFormat output = new VerticaOutputFormat();
     Job job = getVerticaJob();
     VerticaOutputFormat.setOutput(job, "mrtarget", true, "a int", "b boolean",
-        "c char(1)", "d date", "f float", "t timestamp", "v varchar",
-        "z varbinary");
+        "c char(1)", "d date", "f float", "t timestamp", "v VARRRRRRRRchar",
+        "z VARRRRRRRRbinary");
     output.checkOutputSpecs(job, true);
     TaskAttemptContext context = new TaskAttemptContextImpl(job.getConfiguration(),
         new TaskAttemptID());

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/CompletedJobStatusStore.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/CompletedJobStatusStore.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.util.DiskChecker.DiskErrorException;
  * A daemon thread cleans up job info files older than the retain time
  * <p/>
  * The retain time can be set with the 'persist.jobstatus.hours'
- * configuration variable (it is in hours).
+ * configuration VARRRRRRRRiable (it is in hours).
  */
 class CompletedJobStatusStore implements Runnable {
   private boolean active;

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/DefaultTaskController.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/DefaultTaskController.java
@@ -61,7 +61,7 @@ public class DefaultTaskController extends TaskController {
 
     JvmEnv env = context.env;
     List<String> wrappedCommand = 
-      TaskLog.captureOutAndError(env.setup, env.vargs, env.stdout, env.stderr,
+      TaskLog.captureOutAndError(env.setup, env.VARRRRRRRRgs, env.stdout, env.stderr,
           env.logSize, true);
     ShellCommandExecutor shexec = 
         new ShellCommandExecutor(wrappedCommand.toArray(new String[0]), 

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/JobInProgress.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/JobInProgress.java
@@ -2583,13 +2583,13 @@ public class JobInProgress {
       return sum/count;      
     }
   
-    public double var() {
+    public double VARRRRRRRR() {
       // E(X^2) - E(X)^2
       return Math.max((sumSquares/count) - mean() * mean(), 0.0d);
     }
     
     public double std() {
-      return Math.sqrt(this.var());
+      return Math.sqrt(this.VARRRRRRRR());
     }
     
     public String toString() {
@@ -3356,7 +3356,7 @@ public class JobInProgress {
   /**
    * The job is dead.  We're now GC'ing it, getting rid of the job
    * from all tables.  Be sure to remove all of this job's tasks
-   * from the various tables.
+   * from the VARRRRRRRRious tables.
    */
    void garbageCollect() {
      synchronized(this) {

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/JobTracker.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/JobTracker.java
@@ -1228,7 +1228,7 @@ public class JobTracker implements MRConstants, InterTrackerProtocol,
   private int totalReduceTaskCapacity;
   private final HostsFileReader hostsReader;
   
-  // JobTracker recovery variables
+  // JobTracker recovery VARRRRRRRRiables
   private volatile boolean hasRecovered = false;
   private volatile long recoveryDuration;
 

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/JvmManager.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/JvmManager.java
@@ -47,10 +47,10 @@ class JvmManager {
 
   private JvmManagerForType reduceJvmManager;
   
-  public JvmEnv constructJvmEnv(List<String> setup, Vector<String>vargs,
+  public JvmEnv constructJvmEnv(List<String> setup, Vector<String>VARRRRRRRRgs,
       File stdout,File stderr,long logSize, File workDir, 
       Map<String,String> env, JobConf conf) {
-    return new JvmEnv(setup,vargs,stdout,stderr,logSize,workDir,env,conf);
+    return new JvmEnv(setup,VARRRRRRRRgs,stdout,stderr,logSize,workDir,env,conf);
   }
   
   public JvmManager(TaskTracker tracker) {
@@ -464,7 +464,7 @@ class JvmManager {
 
       public void runChild(JvmEnv env) {
         try {
-          env.vargs.add(Integer.toString(jvmId.getId()));
+          env.VARRRRRRRRgs.add(Integer.toString(jvmId.getId()));
           //Launch the task controller to run task JVM
           initalContext.env = env;
           tracker.getTaskController().launchTaskJVM(initalContext);
@@ -572,7 +572,7 @@ class JvmManager {
     }
   }  
   static class JvmEnv { //Helper class
-    List<String> vargs;
+    List<String> VARRRRRRRRgs;
     List<String> setup;
     File stdout;
     File stderr;
@@ -581,11 +581,11 @@ class JvmManager {
     JobConf conf;
     Map<String, String> env;
 
-    public JvmEnv(List<String> setup, Vector<String> vargs, File stdout, 
+    public JvmEnv(List<String> setup, Vector<String> VARRRRRRRRgs, File stdout, 
         File stderr, long logSize, File workDir, Map<String,String> env,
         JobConf conf) {
       this.setup = setup;
-      this.vargs = vargs;
+      this.VARRRRRRRRgs = VARRRRRRRRgs;
       this.stdout = stdout;
       this.stderr = stderr;
       this.workDir = workDir;

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskController.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskController.java
@@ -59,7 +59,7 @@ public abstract class TaskController implements Configurable {
     return conf;
   }
 
-  // The list of directory paths specified in the variable Configs.LOCAL_DIR
+  // The list of directory paths specified in the VARRRRRRRRiable Configs.LOCAL_DIR
   // This is used to determine which among the list of directories is picked up
   // for storing data for a particular task.
   protected String[] mapredLocalDirs;

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskGraphServlet.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskGraphServlet.java
@@ -135,14 +135,14 @@ public class TaskGraphServlet extends HttpServlet {
       if(i >= reports.length) break;
       
       if(isMap) {
-        float progress = getMapAvarageProgress(tasksPerBar, i, reports);
+        float progress = getMapAVARRRRRRRRageProgress(tasksPerBar, i, reports);
         int barHeight = (int)Math.ceil(height * progress);
         int y = height - barHeight + ymargin;
         printRect(out, barWidth, barHeight,x , y , colors[2]);
       }
       else {
         float[] progresses 
-          = getReduceAvarageProgresses(tasksPerBar, i, reports);
+          = getReduceAVARRRRRRRRageProgresses(tasksPerBar, i, reports);
         //draw three bars stacked, for copy, sort, reduce
         
         int prevHeight =0;
@@ -187,7 +187,7 @@ public class TaskGraphServlet extends HttpServlet {
   }
 
   /**Computes average progress per bar*/
-  private float getMapAvarageProgress(int tasksPerBar, int index
+  private float getMapAVARRRRRRRRageProgress(int tasksPerBar, int index
       , TaskReport[] reports ) {
     float progress = 0f;
     int k=0;
@@ -199,7 +199,7 @@ public class TaskGraphServlet extends HttpServlet {
   }
 
   /**Computes average progresses per bar*/
-  private float[] getReduceAvarageProgresses(int tasksPerBar, int index
+  private float[] getReduceAVARRRRRRRRageProgresses(int tasksPerBar, int index
       , TaskReport[] reports ) {
     float[] progresses = new float[] {0,0,0};
     int k=0;

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskMemoryManagerThread.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskMemoryManagerThread.java
@@ -75,7 +75,7 @@ class TaskMemoryManagerThread extends Thread {
     }
   }
 
-  // mainly for test purposes. note that the tasktracker variable is
+  // mainly for test purposes. note that the tasktracker VARRRRRRRRiable is
   // not set here.
   TaskMemoryManagerThread(long maxMemoryAllowedForAllTasks,
                             long monitoringInterval) {

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskRunner.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskRunner.java
@@ -126,11 +126,11 @@ abstract class TaskRunner extends Thread {
   }
   
   /**
-   * Get the environment variables for the child map/reduce tasks.
+   * Get the environment VARRRRRRRRiables for the child map/reduce tasks.
    * @param jobConf job configuration
-   * @return the environment variables for the child map/reduce tasks or
+   * @return the environment VARRRRRRRRiables for the child map/reduce tasks or
    *         <code>null</code> if unspecified
-   * @deprecated Use environment variables specific to the map or reduce tasks
+   * @deprecated Use environment VARRRRRRRRiables specific to the map or reduce tasks
    *             set via {@link JobConf#MAPRED_MAP_TASK_ENV} or
    *             {@link JobConf#MAPRED_REDUCE_TASK_ENV}
    */
@@ -183,7 +183,7 @@ abstract class TaskRunner extends Thread {
       long logSize = TaskLog.getTaskLogLength(conf);
 
       //  Build exec child JVM args.
-      Vector<String> vargs =
+      Vector<String> VARRRRRRRRgs =
           getVMArgs(taskid, workDir, classPaths, logSize);
 
       tracker.addToMemoryManager(t.getTaskID(), t.isMapTask(), conf);
@@ -202,7 +202,7 @@ abstract class TaskRunner extends Thread {
       errorInfo = getVMEnvironment(errorInfo, workDir, conf, env,
                                    taskid, logSize);
 
-      launchJvmAndWait(setup, vargs, stdout, stderr, logSize, workDir, env);
+      launchJvmAndWait(setup, VARRRRRRRRgs, stdout, stderr, logSize, workDir, env);
       tracker.getTaskTrackerInstrumentation().reportTaskEnd(t.getTaskID());
       if (exitCodeSet) {
         if (!killed && exitCode != 0) {
@@ -247,10 +247,10 @@ abstract class TaskRunner extends Thread {
     }
   }
 
-  void launchJvmAndWait(List<String> setup, Vector<String> vargs, File stdout,
+  void launchJvmAndWait(List<String> setup, Vector<String> VARRRRRRRRgs, File stdout,
       File stderr, long logSize, File workDir, Map<String, String> env)
       throws InterruptedException {
-    jvmManager.launchJvm(this, jvmManager.constructJvmEnv(setup, vargs, stdout,
+    jvmManager.launchJvm(this, jvmManager.constructJvmEnv(setup, VARRRRRRRRgs, stdout,
         stderr, logSize, workDir, env, conf));
     synchronized (lock) {
       while (!done) {
@@ -355,11 +355,11 @@ abstract class TaskRunner extends Thread {
   private Vector<String> getVMArgs(TaskAttemptID taskid, File workDir,
       List<String> classPaths, long logSize)
       throws IOException {
-    Vector<String> vargs = new Vector<String>(8);
+    Vector<String> VARRRRRRRRgs = new Vector<String>(8);
     File jvm =                                  // use same jvm as parent
       new File(new File(System.getProperty("java.home"), "bin"), "java");
 
-    vargs.add(jvm.toString());
+    VARRRRRRRRgs.add(jvm.toString());
 
     // Add child (task) java-vm options.
     //
@@ -417,53 +417,53 @@ abstract class TaskRunner extends Thread {
       }
     }
     if(!hasUserLDPath) {
-      vargs.add("-Djava.library.path=" + libraryPath);
+      VARRRRRRRRgs.add("-Djava.library.path=" + libraryPath);
     }
     for (int i = 0; i < javaOptsSplit.length; i++) {
-      vargs.add(javaOptsSplit[i]);
+      VARRRRRRRRgs.add(javaOptsSplit[i]);
     }
 
     Path childTmpDir = createChildTmpDir(workDir, conf);
-    vargs.add("-Djava.io.tmpdir=" + childTmpDir);
+    VARRRRRRRRgs.add("-Djava.io.tmpdir=" + childTmpDir);
 
     // Add classpath.
-    vargs.add("-classpath");
+    VARRRRRRRRgs.add("-classpath");
     String classPath = StringUtils.join(SYSTEM_PATH_SEPARATOR, classPaths);
-    vargs.add(classPath);
+    VARRRRRRRRgs.add(classPath);
 
     // Setup the log4j prop
-    setupLog4jProperties(vargs, taskid, logSize);
+    setupLog4jProperties(VARRRRRRRRgs, taskid, logSize);
 
     if (conf.getProfileEnabled()) {
       if (conf.getProfileTaskRange(t.isMapTask()
                                    ).isIncluded(t.getPartition())) {
         File prof = TaskLog.getTaskLogFile(taskid, t.isTaskCleanupTask(),
             TaskLog.LogName.PROFILE);
-        vargs.add(String.format(conf.getProfileParams(), prof.toString()));
+        VARRRRRRRRgs.add(String.format(conf.getProfileParams(), prof.toString()));
       }
     }
 
     // Add main class and its arguments 
-    vargs.add(Child.class.getName());  // main of Child
+    VARRRRRRRRgs.add(Child.class.getName());  // main of Child
     // pass umbilical address
     InetSocketAddress address = tracker.getTaskTrackerReportAddress();
-    vargs.add(address.getAddress().getHostAddress()); 
-    vargs.add(Integer.toString(address.getPort())); 
-    vargs.add(taskid.toString());                      // pass task identifier
+    VARRRRRRRRgs.add(address.getAddress().getHostAddress()); 
+    VARRRRRRRRgs.add(Integer.toString(address.getPort())); 
+    VARRRRRRRRgs.add(taskid.toString());                      // pass task identifier
     // pass task log location
-    vargs.add(TaskLog.getAttemptDir(taskid, t.isTaskCleanupTask()).toString());
-    return vargs;
+    VARRRRRRRRgs.add(TaskLog.getAttemptDir(taskid, t.isTaskCleanupTask()).toString());
+    return VARRRRRRRRgs;
   }
 
-  private void setupLog4jProperties(Vector<String> vargs, TaskAttemptID taskid,
+  private void setupLog4jProperties(Vector<String> VARRRRRRRRgs, TaskAttemptID taskid,
       long logSize) {
-    vargs.add("-Dhadoop.log.dir=" + 
+    VARRRRRRRRgs.add("-Dhadoop.log.dir=" + 
         new File(System.getProperty("hadoop.log.dir")).getAbsolutePath());
-    vargs.add("-Dhadoop.root.logger=" + getLogLevel(conf).toString() + ",TLA");
-    vargs.add("-D" + TaskLogAppender.TASKID_PROPERTY +  "=" + taskid);
-    vargs.add("-D" + TaskLogAppender.ISCLEANUP_PROPERTY +
+    VARRRRRRRRgs.add("-Dhadoop.root.logger=" + getLogLevel(conf).toString() + ",TLA");
+    VARRRRRRRRgs.add("-D" + TaskLogAppender.TASKID_PROPERTY +  "=" + taskid);
+    VARRRRRRRRgs.add("-D" + TaskLogAppender.ISCLEANUP_PROPERTY +
               "=" + t.isTaskCleanupTask());
-    vargs.add("-D" + TaskLogAppender.LOGSIZE_PROPERTY + "=" + logSize);
+    VARRRRRRRRgs.add("-D" + TaskLogAppender.LOGSIZE_PROPERTY + "=" + logSize);
   }
 
   /**
@@ -514,7 +514,7 @@ abstract class TaskRunner extends Thread {
   }
 
   /**
-   * sets the environment variables needed for task jvm and its children.
+   * sets the environment VARRRRRRRRiables needed for task jvm and its children.
    * @param errorInfo
    * @param workDir
    * @param env
@@ -552,7 +552,7 @@ abstract class TaskRunner extends Thread {
                        + " -Dhadoop.tasklog.totalLogFileSize=" + logSize;
     env.put("HADOOP_CLIENT_OPTS", hadoopClientOpts);
 
-    // add the env variables passed by the user
+    // add the env VARRRRRRRRiables passed by the user
     String mapredChildEnv = getChildEnv(conf);
     if (mapredChildEnv != null && mapredChildEnv.length() > 0) {
       String childEnvs[] = mapredChildEnv.split(",");

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskTracker.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskTracker.java
@@ -2939,18 +2939,18 @@ public class TaskTracker
         }     
       }
       String [] debug = debugCommand.split(" ");
-      List<String> vargs = new ArrayList<String>();
+      List<String> VARRRRRRRRgs = new ArrayList<String>();
       for (String component : debug) {
-        vargs.add(component);
+        VARRRRRRRRgs.add(component);
       }
-      vargs.add(taskStdout);
-      vargs.add(taskStderr);
-      vargs.add(taskSyslog);
-      vargs.add(jobConf);
-      vargs.add(program);
+      VARRRRRRRRgs.add(taskStdout);
+      VARRRRRRRRgs.add(taskStderr);
+      VARRRRRRRRgs.add(taskSyslog);
+      VARRRRRRRRgs.add(jobConf);
+      VARRRRRRRRgs.add(program);
       DebugScriptContext context = 
         new TaskController.DebugScriptContext();
-      context.args = vargs;
+      context.args = VARRRRRRRRgs;
       context.stdout = stdout;
       context.workDir = workDir;
       context.task = task;

--- a/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskTrackerAction.java
+++ b/hadoop-mapreduce-project/src/java/org/apache/hadoop/mapred/TaskTrackerAction.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.io.WritableUtils;
 abstract class TaskTrackerAction implements Writable {
   
   /**
-   * Ennumeration of various 'actions' that the {@link JobTracker}
+   * Ennumeration of VARRRRRRRRious 'actions' that the {@link JobTracker}
    * directs the {@link TaskTracker} to perform periodically.
    * 
    */

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/JHLogAnalyzer.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/JHLogAnalyzer.java
@@ -98,7 +98,7 @@ import org.apache.hadoop.util.StringUtils;
  * In addition to that pending time also includes intervals between attempts
  * of the same task if it was re-executed.
  * <p>
- * History log analyzer calculates two pending time variations. First is based
+ * History log analyzer calculates two pending time VARRRRRRRRiations. First is based
  * on job submission time as described above, second, starts the wait interval
  * when the job is launched rather than submitted.
  * 

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/ConfigMerger.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/ConfigMerger.java
@@ -199,7 +199,7 @@ class ConfigMerger {
    */
   private Configuration handleOptions(ParsedOutput opts, Configuration base)
       throws ConfigException {
-    // ensure variables are overwritten and verified
+    // ensure VARRRRRRRRiables are overwritten and verified
     ConfigExtractor extractor = new ConfigExtractor(base);
     // overwrite the map amount and check to ensure > 0
     {

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/Constants.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/Constants.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.fs.slive;
 
 /**
- * Constants used in various places in slive
+ * Constants used in VARRRRRRRRious places in slive
  */
 class Constants {
 

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/Operation.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/Operation.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.slive.OperationOutput.OutputType;
 /**
  * An operation provides these abstractions and if it desires to perform any
  * operations it must implement a override of the run() function to provide
- * varying output to be captured.
+ * VARRRRRRRRying output to be captured.
  */
 abstract class Operation {
 

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/ReportWriter.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/ReportWriter.java
@@ -98,10 +98,10 @@ class ReportWriter {
   /**
    * Provides a more detailed report for a given operation. This will output the
    * keys and values for all input and then sort based on measurement type and
-   * attempt to show rates for various metrics which have expected types to be
+   * attempt to show rates for VARRRRRRRRious metrics which have expected types to be
    * able to measure there rate. Currently this will show rates for bytes
    * written, success count, files created, directory entries, op count and
-   * bytes read if the variable for time taken is available for each measurement
+   * bytes read if the VARRRRRRRRiable for time taken is available for each measurement
    * type.
    * 
    * @param operation

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/SliveMapper.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/SliveMapper.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.util.StringUtils;
 
 /**
  * The slive class which sets up the mapper to be used which itself will receive
- * a single dummy key and value and then in a loop run the various operations
+ * a single dummy key and value and then in a loop run the VARRRRRRRRious operations
  * that have been selected and upon operation completion output the collected
  * output from that operation (and repeat until finished).
  */

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/Weights.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/Weights.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.fs.slive;
 import org.apache.hadoop.fs.slive.WeightSelector.Weightable;
 
 /**
- * Class to isolate the various weight algorithms we use.
+ * Class to isolate the VARRRRRRRRious weight algorithms we use.
  */
 class Weights {
   private Weights() {

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/hdfs/NNBenchWithoutMR.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/hdfs/NNBenchWithoutMR.java
@@ -48,7 +48,7 @@ public class NNBenchWithoutMR {
   private static final Log LOG = LogFactory.getLog(
                                             "org.apache.hadoop.hdfs.NNBench");
   
-  // variable initialzed from command line arguments
+  // VARRRRRRRRiable initialzed from command line arguments
   private static long startTime = 0;
   private static int numFiles = 0;
   private static long bytesPerBlock = 1;
@@ -56,7 +56,7 @@ public class NNBenchWithoutMR {
   private static long bytesPerFile = 1;
   private static Path baseDir = null;
     
-  // variables initialized in main()
+  // VARRRRRRRRiables initialized in main()
   private static FileSystem fileSys = null;
   private static Path taskDir = null;
   private static byte[] buffer;

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/io/FileBench.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/io/FileBench.java
@@ -589,7 +589,7 @@ public class FileBench extends Configured implements Tool {
     "molecule", "autobiographist", "reciprocation", "refective",
     "unobservantness", "tricae", "ungouged", "floatability",
     "Mesua", "fetlocked", "chordacentrum", "sedentariness",
-    "various", "laubanite", "nectopod", "zenick",
+    "VARRRRRRRRious", "laubanite", "nectopod", "zenick",
     "sequentially", "analgic", "biodynamics", "posttraumatic",
     "nummi", "pyroacetic", "bot", "redescend",
     "dispermy", "undiffusive", "circular", "trillion",

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/GenericMRLoadGenerator.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/GenericMRLoadGenerator.java
@@ -685,7 +685,7 @@ public class GenericMRLoadGenerator extends Configured implements Tool {
     "molecule", "autobiographist", "reciprocation", "refective",
     "unobservantness", "tricae", "ungouged", "floatability",
     "Mesua", "fetlocked", "chordacentrum", "sedentariness",
-    "various", "laubanite", "nectopod", "zenick",
+    "VARRRRRRRRious", "laubanite", "nectopod", "zenick",
     "sequentially", "analgic", "biodynamics", "posttraumatic",
     "nummi", "pyroacetic", "bot", "redescend",
     "dispermy", "undiffusive", "circular", "trillion",

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/MRCaching.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/MRCaching.java
@@ -309,7 +309,7 @@ public class MRCaching {
 
     // Check to ensure the filesizes of files in DC were correctly saved.
     // Note, the underlying job clones the original conf before determine
-    // various stats (timestamps etc.), so we have to getConfiguration here.
+    // VARRRRRRRRious stats (timestamps etc.), so we have to getConfiguration here.
     validateCacheFileSizes(job.getConfiguration(), fileSizes,
                            MRJobConfig.CACHE_FILES_SIZES);
     validateCacheFileSizes(job.getConfiguration(), archiveSizes,

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestConcatenatedCompressedInput.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestConcatenatedCompressedInput.java
@@ -374,7 +374,7 @@ public class TestConcatenatedCompressedInput {
     int bufferSize;
 
     // ideally would add some offsets/shifts in here (e.g., via extra fields
-    // of various sizes), but...significant work to hand-generate each header
+    // of VARRRRRRRRious sizes), but...significant work to hand-generate each header
     for (bufferSize = 1; bufferSize < 34; ++bufferSize) {
       jConf.setInt("io.file.buffer.size", bufferSize);
       doSingleGzipBufferSize(jConf);

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestJobInProgress.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestJobInProgress.java
@@ -214,7 +214,7 @@ public class TestJobInProgress extends TestCase {
   }
 
   /**
-   * Test if running tasks are correctly maintained for various types of jobs
+   * Test if running tasks are correctly maintained for VARRRRRRRRious types of jobs
    */
   static void testRunningTaskCount(boolean speculation)  throws Exception {
     LOG.info("Testing running jobs with speculation : " + speculation); 

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestJvmManager.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestJvmManager.java
@@ -113,8 +113,8 @@ public class TestJvmManager {
     File pidFile = new File(TEST_DIR, "pid");
     final TaskRunner taskRunner = new MapTaskRunner(tip, tt, taskConf);
     // launch a jvm which sleeps for 60 seconds
-    final Vector<String> vargs = new Vector<String>(2);
-    vargs.add(writeScript("SLEEP", "sleep 60\n", pidFile).getAbsolutePath());
+    final Vector<String> VARRRRRRRRgs = new Vector<String>(2);
+    VARRRRRRRRgs.add(writeScript("SLEEP", "sleep 60\n", pidFile).getAbsolutePath());
     final File workDir = new File(TEST_DIR, "work");
     workDir.mkdir();
     final File stdout = new File(TEST_DIR, "stdout");
@@ -124,7 +124,7 @@ public class TestJvmManager {
     Thread launcher = new Thread() {
       public void run() {
         try {
-          taskRunner.launchJvmAndWait(null, vargs, stdout, stderr, 100,
+          taskRunner.launchJvmAndWait(null, VARRRRRRRRgs, stdout, stderr, 100,
               workDir, null);
         } catch (InterruptedException e) {
           e.printStackTrace();
@@ -175,14 +175,14 @@ public class TestJvmManager {
     task.setConf(taskConf);
     tip = tt.new TaskInProgress(task, taskConf);
     TaskRunner taskRunner2 = new MapTaskRunner(tip, tt, taskConf);
-    // build dummy vargs to call ls
-    Vector<String> vargs2 = new Vector<String>(1);
-    vargs2.add(writeScript("LS", "ls", pidFile).getAbsolutePath());
+    // build dummy VARRRRRRRRgs to call ls
+    Vector<String> VARRRRRRRRgs2 = new Vector<String>(1);
+    VARRRRRRRRgs2.add(writeScript("LS", "ls", pidFile).getAbsolutePath());
     File workDir2 = new File(TEST_DIR, "work2");
     workDir.mkdir();
     File stdout2 = new File(TEST_DIR, "stdout2");
     File stderr2 = new File(TEST_DIR, "stderr2");
-    taskRunner2.launchJvmAndWait(null, vargs2, stdout2, stderr2, 100, workDir2,
+    taskRunner2.launchJvmAndWait(null, VARRRRRRRRgs2, stdout2, stderr2, 100, workDir2,
         null);
     // join all the threads
     killer.join();
@@ -193,7 +193,7 @@ public class TestJvmManager {
 
   /**
    * Create a bunch of tasks and use a special hash map to detect
-   * racy access to the various internal data structures of JvmManager.
+   * racy access to the VARRRRRRRRious internal data structures of JvmManager.
    * (Regression test for MAPREDUCE-2224)
    */
   @Test
@@ -220,8 +220,8 @@ public class TestJvmManager {
       File pidFile = new File(TEST_DIR, "pid_" + i);
       final TaskRunner taskRunner = new MapTaskRunner(tip, tt, taskConf);
       // launch a jvm which sleeps for 60 seconds
-      final Vector<String> vargs = new Vector<String>(2);
-      vargs.add(writeScript("script_" + i, "echo hi\n", pidFile).getAbsolutePath());
+      final Vector<String> VARRRRRRRRgs = new Vector<String>(2);
+      VARRRRRRRRgs.add(writeScript("script_" + i, "echo hi\n", pidFile).getAbsolutePath());
       final File workDir = new File(TEST_DIR, "work_" + i);
       workDir.mkdir();
       final File stdout = new File(TEST_DIR, "stdout_" + i);
@@ -231,7 +231,7 @@ public class TestJvmManager {
       Runnable launcher = new Runnable() {
         public void run() {
           try {
-            taskRunner.launchJvmAndWait(null, vargs, stdout, stderr, 100,
+            taskRunner.launchJvmAndWait(null, VARRRRRRRRgs, stdout, stderr, 100,
                 workDir, null);
           } catch (Throwable t) {
             failed.compareAndSet(null, t);

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestKeyValueTextInputFormat.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestKeyValueTextInputFormat.java
@@ -62,7 +62,7 @@ public class TestKeyValueTextInputFormat extends TestCase {
     localFs.delete(workDir, true);
     FileInputFormat.setInputPaths(job, workDir);
 
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length+= random.nextInt(MAX_LENGTH/10)+1) {
 
@@ -81,7 +81,7 @@ public class TestKeyValueTextInputFormat extends TestCase {
         writer.close();
       }
 
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       KeyValueTextInputFormat format = new KeyValueTextInputFormat();
       format.configure(job);
       for (int i = 0; i < 3; i++) {

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestMiniMRChildTask.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestMiniMRChildTask.java
@@ -191,17 +191,17 @@ public class TestMiniMRChildTask extends TestCase {
     String envValue = System.getenv(envName).trim();
     if ("append".equals(mode)) {
       if (envValue == null || !envValue.contains(":")) {
-        throw new RuntimeException("Missing env variable");
+        throw new RuntimeException("Missing env VARRRRRRRRiable");
       } else {
         String parts[] = envValue.split(":");
         // check if the value is appended
         if (!parts[parts.length - 1].equals(expValue)) {
-          throw new RuntimeException("Wrong env variable in append mode");
+          throw new RuntimeException("Wrong env VARRRRRRRRiable in append mode");
         }
       }
     } else {
       if (envValue == null || !envValue.equals(expValue)) {
-        throw new RuntimeException("Wrong env variable in noappend mode");
+        throw new RuntimeException("Wrong env VARRRRRRRRiable in noappend mode");
       }
     }
   }
@@ -240,11 +240,11 @@ public class TestMiniMRChildTask extends TestCase {
       checkEnv("LD_LIBRARY_PATH", "/tmp", "append");
       // check if X=/tmp works for an already existing parameter
       checkEnv("HOME", "/tmp", "noappend");
-      // check if X=/tmp for a new env variable
+      // check if X=/tmp for a new env VARRRRRRRRiable
       checkEnv("MY_PATH", "/tmp", "noappend");
-      // check if X=$X:/tmp works for a new env var and results into :/tmp
+      // check if X=$X:/tmp works for a new env VARRRRRRRR and results into :/tmp
       checkEnv("NEW_PATH", ":/tmp", "noappend");
-      // check if X=$(tt's X var):/tmp for an old env variable inherited from 
+      // check if X=$(tt's X VARRRRRRRR):/tmp for an old env VARRRRRRRRiable inherited from 
       // the tt
       checkEnv("PATH",  path + ":/tmp", "noappend");
     }
@@ -290,11 +290,11 @@ public class TestMiniMRChildTask extends TestCase {
       checkEnv("LD_LIBRARY_PATH", "/tmp", "append");
       // check if X=/tmp works for an already existing parameter
       checkEnv("HOME", "/tmp", "noappend");
-      // check if X=/tmp for a new env variable
+      // check if X=/tmp for a new env VARRRRRRRRiable
       checkEnv("MY_PATH", "/tmp", "noappend");
-      // check if X=$X:/tmp works for a new env var and results into :/tmp
+      // check if X=$X:/tmp works for a new env VARRRRRRRR and results into :/tmp
       checkEnv("NEW_PATH", ":/tmp", "noappend");
-      // check if X=$(tt's X var):/tmp for an old env variable inherited from 
+      // check if X=$(tt's X VARRRRRRRR):/tmp for an old env VARRRRRRRRiable inherited from 
       // the tt
       checkEnv("PATH",  path + ":/tmp", "noappend");
 
@@ -368,9 +368,9 @@ public class TestMiniMRChildTask extends TestCase {
   }
 
   /**
-   * Test to test if the user set env variables reflect in the child
+   * Test to test if the user set env VARRRRRRRRiables reflect in the child
    * processes. Mainly
-   *   - x=y (x can be a already existing env variable or a new variable)
+   *   - x=y (x can be a already existing env VARRRRRRRRiable or a new VARRRRRRRRiable)
    *   - x=$x:y (replace $x with the current value of x)
    */
   public void testTaskEnv(){
@@ -390,9 +390,9 @@ public class TestMiniMRChildTask extends TestCase {
   }
   
   /**
-   * Test to test if the user set *old* env variables reflect in the child
+   * Test to test if the user set *old* env VARRRRRRRRiables reflect in the child
    * processes. Mainly
-   *   - x=y (x can be a already existing env variable or a new variable)
+   *   - x=y (x can be a already existing env VARRRRRRRRiable or a new VARRRRRRRRiable)
    *   - x=$x:y (replace $x with the current value of x)
    */
   public void testTaskOldEnv(){
@@ -417,11 +417,11 @@ public class TestMiniMRChildTask extends TestCase {
     configure(conf, inDir, outDir, input, 
               EnvCheckMapper.class, EnvCheckReducer.class);
     // test 
-    //  - new SET of new var (MY_PATH)
-    //  - set of old var (HOME)
-    //  - append to an old var from modified env (LD_LIBRARY_PATH)
-    //  - append to an old var from tt's env (PATH)
-    //  - append to a new var (NEW_PATH)
+    //  - new SET of new VARRRRRRRR (MY_PATH)
+    //  - set of old VARRRRRRRR (HOME)
+    //  - append to an old VARRRRRRRR from modified env (LD_LIBRARY_PATH)
+    //  - append to an old VARRRRRRRR from tt's env (PATH)
+    //  - append to a new VARRRRRRRR (NEW_PATH)
     String mapTaskEnvKey = JobConf.MAPRED_MAP_TASK_ENV;
     String reduceTaskEnvKey = JobConf.MAPRED_MAP_TASK_ENV;
     String mapTaskJavaOptsKey = JobConf.MAPRED_MAP_TASK_JAVA_OPTS;

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestSequenceFileAsTextInputFormat.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestSequenceFileAsTextInputFormat.java
@@ -50,7 +50,7 @@ public class TestSequenceFileAsTextInputFormat extends TestCase {
 
     FileInputFormat.setInputPaths(job, dir);
 
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length+= random.nextInt(MAX_LENGTH/10)+1) {
 
@@ -70,7 +70,7 @@ public class TestSequenceFileAsTextInputFormat extends TestCase {
         writer.close();
       }
 
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       InputFormat<Text, Text> format =
         new SequenceFileAsTextInputFormat();
       

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestSequenceFileInputFilter.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestSequenceFileInputFilter.java
@@ -108,7 +108,7 @@ public class TestSequenceFileInputFilter extends TestCase {
     // clean input dir
     fs.delete(inDir, true);
   
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 1; length < MAX_LENGTH;
          length+= random.nextInt(MAX_LENGTH/10)+1) {
       LOG.info("******Number of records: "+length);
@@ -131,7 +131,7 @@ public class TestSequenceFileInputFilter extends TestCase {
     // clean input dir
     fs.delete(inDir, true);
     
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length+= random.nextInt(MAX_LENGTH/10)+1) {
       LOG.info("******Number of records: "+length);
@@ -158,7 +158,7 @@ public class TestSequenceFileInputFilter extends TestCase {
     // clean input dir
     fs.delete(inDir, true);
     
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length+= random.nextInt(MAX_LENGTH/10)+1) {
       LOG.info("******Number of records: "+length);

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestSequenceFileInputFormat.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestSequenceFileInputFormat.java
@@ -50,7 +50,7 @@ public class TestSequenceFileInputFormat extends TestCase {
 
     FileInputFormat.setInputPaths(job, dir);
 
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length+= random.nextInt(MAX_LENGTH/10)+1) {
 
@@ -72,7 +72,7 @@ public class TestSequenceFileInputFormat extends TestCase {
         writer.close();
       }
 
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       InputFormat<IntWritable, BytesWritable> format =
         new SequenceFileInputFormat<IntWritable, BytesWritable>();
       IntWritable key = new IntWritable();

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestSetupAndCleanupFailure.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestSetupAndCleanupFailure.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.mapreduce.server.jobtracker.JTConfig;
 import org.apache.hadoop.mapreduce.server.tasktracker.TTConfig;
 
 /**
- * Tests various failures in setup/cleanup of job, like 
+ * Tests VARRRRRRRRious failures in setup/cleanup of job, like 
  * throwing exception, command line kill and lost tracker 
  */
 public class TestSetupAndCleanupFailure extends TestCase {

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestTextInputFormat.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/TestTextInputFormat.java
@@ -80,7 +80,7 @@ public class TestTextInputFormat {
     localFs.delete(workDir, true);
     FileInputFormat.setInputPaths(job, workDir);
 
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length+= random.nextInt(MAX_LENGTH/10)+1) {
 
@@ -97,7 +97,7 @@ public class TestTextInputFormat {
         writer.close();
       }
 
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       TextInputFormat format = new TextInputFormat();
       format.configure(job);
       LongWritable key = new LongWritable();
@@ -170,7 +170,7 @@ public class TestTextInputFormat {
 
     final int MAX_LENGTH = 500000;
 
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = MAX_LENGTH / 2; length < MAX_LENGTH;
         length += random.nextInt(MAX_LENGTH / 4)+1) {
 
@@ -189,7 +189,7 @@ public class TestTextInputFormat {
         writer.close();
       }
 
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       TextInputFormat format = new TextInputFormat();
       format.configure(conf);
       LongWritable key = new LongWritable();
@@ -263,7 +263,7 @@ public class TestTextInputFormat {
   }
 
   /**
-   * Test readLine for various kinds of line termination sequneces.
+   * Test readLine for VARRRRRRRRious kinds of line termination sequneces.
    * Varies buffer size to stress test.  Also check that returned
    * value matches the string length.
    *

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/jobcontrol/JobControlTestUtils.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/jobcontrol/JobControlTestUtils.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.mapred.Reducer;
 import org.apache.hadoop.mapred.Reporter;
 
 /**
- * Utility methods used in various Job Control unit tests.
+ * Utility methods used in VARRRRRRRRious Job Control unit tests.
  */
 public class JobControlTestUtils {
 

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/lib/TestLineInputFormat.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapred/lib/TestLineInputFormat.java
@@ -56,7 +56,7 @@ public class TestLineInputFormat extends TestCase {
     int numLinesPerMap = 5;
     job.setInt("mapreduce.input.lineinputformat.linespermap", numLinesPerMap);
 
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length += random.nextInt(MAX_LENGTH/10) + 1) {
       // create a file with length entries

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/GenericMRLoadGenerator.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/GenericMRLoadGenerator.java
@@ -702,7 +702,7 @@ public class GenericMRLoadGenerator extends Configured implements Tool {
     "molecule", "autobiographist", "reciprocation", "refective",
     "unobservantness", "tricae", "ungouged", "floatability",
     "Mesua", "fetlocked", "chordacentrum", "sedentariness",
-    "various", "laubanite", "nectopod", "zenick",
+    "VARRRRRRRRious", "laubanite", "nectopod", "zenick",
     "sequentially", "analgic", "biodynamics", "posttraumatic",
     "nummi", "pyroacetic", "bot", "redescend",
     "dispermy", "undiffusive", "circular", "trillion",

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEvents.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/jobhistory/TestJobHistoryEvents.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.TaskType;
 
 /**
- * Test various jobhistory events
+ * Test VARRRRRRRRious jobhistory events
  */
 public class TestJobHistoryEvents extends TestCase {
   static final int[][] NULL_SPLITS_ARRAY
@@ -38,7 +38,7 @@ public class TestJobHistoryEvents extends TestCase {
   }
  
   /**
-   * Test {@link TaskAttemptStartedEvent} for various task types.
+   * Test {@link TaskAttemptStartedEvent} for VARRRRRRRRious task types.
    */
   private static void testAttemptStartedEventForTypes(EventType expected, 
                                                       TaskAttemptID id,
@@ -74,7 +74,7 @@ public class TestJobHistoryEvents extends TestCase {
   }
   
   /**
-   * Test {@link TaskAttemptUnsuccessfulCompletionEvent} for various task types.
+   * Test {@link TaskAttemptUnsuccessfulCompletionEvent} for VARRRRRRRRious task types.
    */
   private static void testFailedKilledEventsForTypes(EventType expected, 
                                                      TaskAttemptID id,
@@ -124,7 +124,7 @@ public class TestJobHistoryEvents extends TestCase {
   }
   
   /**
-   * Test {@link TaskAttemptFinishedEvent} for various task types.
+   * Test {@link TaskAttemptFinishedEvent} for VARRRRRRRRious task types.
    */
   private static void testFinishedEventsForTypes(EventType expected, 
                                                  TaskAttemptID id,

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/lib/input/TestMRKeyValueTextInputFormat.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/lib/input/TestMRKeyValueTextInputFormat.java
@@ -80,7 +80,7 @@ public class TestMRKeyValueTextInputFormat {
     FileInputFormat.setInputPaths(job, workDir);
 
     final int MAX_LENGTH = 10000;
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length += random.nextInt(MAX_LENGTH / 10) + 1) {
 
@@ -99,7 +99,7 @@ public class TestMRKeyValueTextInputFormat {
         writer.close();
       }
 
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       KeyValueTextInputFormat format = new KeyValueTextInputFormat();
       for (int i = 0; i < 3; i++) {
         int numSplits = random.nextInt(MAX_LENGTH / 20) + 1;
@@ -179,7 +179,7 @@ public class TestMRKeyValueTextInputFormat {
 
     final int MAX_LENGTH = 500000;
     FileInputFormat.setMaxInputSplitSize(job, MAX_LENGTH / 20);
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length += random.nextInt(MAX_LENGTH / 4) + 1) {
 
@@ -199,7 +199,7 @@ public class TestMRKeyValueTextInputFormat {
         writer.close();
       }
 
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       KeyValueTextInputFormat format = new KeyValueTextInputFormat();
       assertTrue("KVTIF claims not splittable", format.isSplitable(job, file));
       for (int i = 0; i < 3; i++) {

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileAsTextInputFormat.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileAsTextInputFormat.java
@@ -50,7 +50,7 @@ public class TestMRSequenceFileAsTextInputFormat extends TestCase {
 
     FileInputFormat.setInputPaths(job, dir);
 
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length += random.nextInt(MAX_LENGTH / 10) + 1) {
 
@@ -70,7 +70,7 @@ public class TestMRSequenceFileAsTextInputFormat extends TestCase {
 
       TaskAttemptContext context = MapReduceTestUtil.
         createDummyMapTaskAttemptContext(job.getConfiguration());
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       InputFormat<Text, Text> format =
         new SequenceFileAsTextInputFormat();
       

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileInputFilter.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileInputFilter.java
@@ -125,7 +125,7 @@ public class TestMRSequenceFileInputFilter extends TestCase {
     // clean input dir
     fs.delete(inDir, true);
   
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 1; length < MAX_LENGTH;
          length += random.nextInt(MAX_LENGTH / 10) + 1) {
       LOG.info("******Number of records: " + length);
@@ -149,7 +149,7 @@ public class TestMRSequenceFileInputFilter extends TestCase {
     // clean input dir
     fs.delete(inDir, true);
     
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length += random.nextInt(MAX_LENGTH / 10) + 1) {
       LOG.info("******Number of records: "+length);
@@ -177,7 +177,7 @@ public class TestMRSequenceFileInputFilter extends TestCase {
     // clean input dir
     fs.delete(inDir, true);
     
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length += random.nextInt(MAX_LENGTH / 10) + 1) {
       LOG.info("******Number of records: " + length);

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/lib/input/TestNLineInputFormat.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/mapreduce/lib/input/TestNLineInputFormat.java
@@ -57,7 +57,7 @@ public class TestNLineInputFormat extends TestCase {
     FileInputFormat.setInputPaths(job, workDir);
     int numLinesPerMap = 5;
     NLineInputFormat.setNumLinesPerSplit(job, numLinesPerMap);
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length += random.nextInt(MAX_LENGTH / 10) + 1) {
       // create a file with length entries

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/record/TestRecordWritable.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/record/TestRecordWritable.java
@@ -54,7 +54,7 @@ public class TestRecordWritable extends TestCase {
 
     FileInputFormat.setInputPaths(job, dir);
 
-    // for a variety of lengths
+    // for a VARRRRRRRRiety of lengths
     for (int length = 0; length < MAX_LENGTH;
          length+= random.nextInt(MAX_LENGTH/10)+1) {
 
@@ -76,7 +76,7 @@ public class TestRecordWritable extends TestCase {
         writer.close();
       }
 
-      // try splitting the file in a variety of sizes
+      // try splitting the file in a VARRRRRRRRiety of sizes
       InputFormat<RecInt, RecBuffer> format =
         new SequenceFileInputFormat<RecInt, RecBuffer>();
       RecInt key = new RecInt();

--- a/hadoop-mapreduce-project/src/test/system/test/org/apache/hadoop/mapred/TestDistributedCacheModifiedFile.java
+++ b/hadoop-mapreduce-project/src/test/system/test/org/apache/hadoop/mapred/TestDistributedCacheModifiedFile.java
@@ -209,7 +209,7 @@ public class TestDistributedCacheModifiedFile {
           taskTracker = UtilsForTests.getFQDNofTT(taskTracker);
           LOG.info("taskTracker is :" + taskTracker);
 
-          // The tasktrackerFound variable is initialized
+          // The tasktrackerFound VARRRRRRRRiable is initialized
           taskTrackerFound = false;
 
           // This will be entered from the second job onwards

--- a/hadoop-mapreduce-project/src/test/system/test/org/apache/hadoop/mapred/TestFileOwner.java
+++ b/hadoop-mapreduce-project/src/test/system/test/org/apache/hadoop/mapred/TestFileOwner.java
@@ -80,7 +80,7 @@ public class TestFileOwner {
         cluster.getJTClient().getClient().getJob(
             org.apache.hadoop.mapred.JobID.downgrade(slpJob.getJobID()));
     taskController = conf.get(TTConfig.TT_TASK_CONTROLLER);
-    // get the job info so we can get the env variables from the daemon.
+    // get the job info so we can get the env VARRRRRRRRiables from the daemon.
     // Now wait for the task to be in the running state, only then the
     // directories will be created
     JobInfo info = wovenClient.getJobInfo(rJob.getID());

--- a/hadoop-mapreduce-project/src/test/system/test/org/apache/hadoop/mapred/TestPushConfig.java
+++ b/hadoop-mapreduce-project/src/test/system/test/org/apache/hadoop/mapred/TestPushConfig.java
@@ -76,7 +76,7 @@ public class TestPushConfig {
     File file = new File(mapredConf);
     origconf.writeXml(new FileOutputStream(file));    
     Configuration daemonConf =  cluster.getJTClient().getProxy().getDaemonConf();
-    Assert.assertTrue("Dummy varialble is expected to be null before restart.",
+    Assert.assertTrue("Dummy VARRRRRRRRialble is expected to be null before restart.",
         daemonConf.get(DUMMY_CONFIG_STRING) == null);
     String newDir = cluster.getClusterManager().pushConfig(localDir);
     cluster.stop();
@@ -88,7 +88,7 @@ public class TestPushConfig {
     waitForClusterStart(cli);
     // make sure the cluster has actually started
     Configuration newconf = cluster.getJTClient().getProxy().getDaemonConf();
-    Assert.assertTrue("Extra varialble is expected to be set",
+    Assert.assertTrue("Extra VARRRRRRRRialble is expected to be set",
         newconf.get(DUMMY_CONFIG_STRING).equals(DUMMY_CONFIG_STRING_VALUE));
     cluster.getClusterManager().stop(newDir);
     cli = cluster.getJTClient();
@@ -99,7 +99,7 @@ public class TestPushConfig {
     cli = cluster.getJTClient();    
     waitForClusterStart(cli);  
     daemonConf =  cluster.getJTClient().getProxy().getDaemonConf();
-    Assert.assertTrue("Dummy variable is expected to be null after restart.",
+    Assert.assertTrue("Dummy VARRRRRRRRiable is expected to be null after restart.",
         daemonConf.get(DUMMY_CONFIG_STRING) == null);
     lFile.delete();
   }

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/DeskewedJobTraceReader.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/DeskewedJobTraceReader.java
@@ -33,12 +33,12 @@ public class DeskewedJobTraceReader implements Closeable {
   // underlying engine
   private final JobTraceReader reader;
 
-  // configuration variables
+  // configuration VARRRRRRRRiables
   private final int skewBufferLength;
 
   private final boolean abortOnUnfixableSkew;
 
-  // state variables
+  // state VARRRRRRRRiables
   private long skewMeasurementLatestSubmitTime = Long.MIN_VALUE;
 
   private long returnedLatestSubmitTime = Long.MIN_VALUE;

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/HadoopLogsAnalyzer.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/HadoopLogsAnalyzer.java
@@ -66,7 +66,7 @@ import org.codehaus.jackson.map.SerializationConfig;
 /**
  * This is the main class for rumen log mining functionality.
  * 
- * It reads a directory of job tracker logs, and computes various information
+ * It reads a directory of job tracker logs, and computes VARRRRRRRRious information
  * about it. See {@code usage()}, below.
  * 
  */

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/Histogram.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/Histogram.java
@@ -128,7 +128,7 @@ class Histogram implements Iterable<Map.Entry<Long, Long>> {
     int bucketCursor = 0;
 
     
-    // Loop invariant: the item at buckets[bucketCursor] can still be reached
+    // Loop inVARRRRRRRRiant: the item at buckets[bucketCursor] can still be reached
     // from iter, and the number of logged elements no longer available from
     // iter is cumulativeCount.
     // 

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedDiscreteCDF.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedDiscreteCDF.java
@@ -25,7 +25,7 @@ import java.util.List;
  * distribution function, with this class set up to meet the requirements of the
  * Jackson JSON parser/generator.
  * 
- * All of the public methods are simply accessors for the instance variables we
+ * All of the public methods are simply accessors for the instance VARRRRRRRRiables we
  * want to write out in the JSON files.
  * 
  */

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedJob.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedJob.java
@@ -34,7 +34,7 @@ import org.codehaus.jackson.annotate.JsonAnySetter;
  * details of this class set up to meet the requirements of the Jackson JSON
  * parser/generator.
  * 
- * All of the public methods are simply accessors for the instance variables we
+ * All of the public methods are simply accessors for the instance VARRRRRRRRiables we
  * want to write out in the JSON files.
  * 
  */

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedLocation.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedLocation.java
@@ -39,7 +39,7 @@ import org.codehaus.jackson.annotate.JsonAnySetter;
  * The details of this class are set up to meet the requirements of the Jackson
  * JSON parser/generator.
  * 
- * All of the public methods are simply accessors for the instance variables we
+ * All of the public methods are simply accessors for the instance VARRRRRRRRiables we
  * want to write out in the JSON files.
  * 
  */

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedNetworkTopology.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedNetworkTopology.java
@@ -35,7 +35,7 @@ import org.codehaus.jackson.annotate.JsonAnySetter;
  * hierarchy of hosts. The current version requires the tree to have all leaves
  * at the same level.
  * 
- * All of the public methods are simply accessors for the instance variables we
+ * All of the public methods are simply accessors for the instance VARRRRRRRRiables we
  * want to write out in the JSON files.
  * 
  */

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedSingleRelativeRanking.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedSingleRelativeRanking.java
@@ -26,7 +26,7 @@ import org.codehaus.jackson.annotate.JsonAnySetter;
  * A {@link LoggedSingleRelativeRanking} represents an X-Y coordinate of a
  * single point in a discrete CDF.
  * 
- * All of the public methods are simply accessors for the instance variables we
+ * All of the public methods are simply accessors for the instance VARRRRRRRRiables we
  * want to write out in the JSON files.
  * 
  */

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedTask.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedTask.java
@@ -35,7 +35,7 @@ import org.codehaus.jackson.annotate.JsonAnySetter;
  * It knows about the [pssibly empty] sequence of attempts, its I/O footprint,
  * and its runtime.
  * 
- * All of the public methods are simply accessors for the instance variables we
+ * All of the public methods are simply accessors for the instance VARRRRRRRRiables we
  * want to write out in the JSON files.
  * 
  */

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedTaskAttempt.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/LoggedTaskAttempt.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.mapreduce.jobhistory.JhCounters;
  * A {@link LoggedTaskAttempt} represents an attempt to run an hadoop task in a
  * hadoop job. Note that a task can have several attempts.
  * 
- * All of the public methods are simply accessors for the instance variables we
+ * All of the public methods are simply accessors for the instance VARRRRRRRRiables we
  * want to write out in the JSON files.
  * 
  */

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/ZombieJob.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/ZombieJob.java
@@ -785,7 +785,7 @@ public class ZombieJob implements JobStory {
 
   /**
    * Perform a weighted random selection on a list of CDFs, and produce a random
-   * variable using the selected CDF.
+   * VARRRRRRRRiable using the selected CDF.
    * 
    * @param mapAttemptCDFs
    *          A list of CDFs for the distribution of runtime for the 1st, 2nd,

--- a/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/package-info.java
+++ b/hadoop-mapreduce-project/src/tools/org/apache/hadoop/tools/rumen/package-info.java
@@ -313,7 +313,7 @@
  *    {@link org.apache.hadoop.tools.rumen.JobTraceReader}<br>
  *      A reader for reading {@link org.apache.hadoop.tools.rumen.LoggedJob} serialized using 
  *      {@link org.apache.hadoop.tools.rumen.DefaultOutputter}. {@link org.apache.hadoop.tools.rumen.LoggedJob} 
- *      provides various APIs for extracting job details. Following are the most
+ *      provides VARRRRRRRRious APIs for extracting job details. Following are the most
  *      commonly used ones
  *        <ul>
  *          <li>{@link org.apache.hadoop.tools.rumen.LoggedJob#getMapTasks()} : Get the map tasks</li>

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/Environment.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/Environment.java
@@ -59,7 +59,7 @@ public class Environment extends Properties {
       throw new RuntimeException("Operating system " + OS + " not supported by this class");
     }
 
-    // Read the environment variables
+    // Read the environment VARRRRRRRRiables
 
     Process pid = Runtime.getRuntime().exec(command);
     BufferedReader in = new BufferedReader(new InputStreamReader(pid.getInputStream()));

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PathFinder.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PathFinder.java
@@ -42,7 +42,7 @@ public class PathFinder {
 
   /**
    * Construct a PathFinder object using the path from the specified system
-   * environment variable.
+   * environment VARRRRRRRRiable.
    */
   public PathFinder(String envpath) {
     pathenv = System.getenv(envpath);

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapRed.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/PipeMapRed.java
@@ -184,7 +184,7 @@ public abstract class PipeMapRed {
       // argvSplit[0]:
       // An absolute path should be a preexisting valid path on all TaskTrackers
       // A relative path is converted into an absolute pathname by looking
-      // up the PATH env variable. If it still fails, look it up in the
+      // up the PATH env VARRRRRRRRiable. If it still fails, look it up in the
       // tasktracker's local working directory
       //
       if (!new File(argvSplit[0]).isAbsolute()) {
@@ -200,7 +200,7 @@ public abstract class PipeMapRed {
       Environment childEnv = (Environment) StreamUtil.env().clone();
       addJobConfToEnvironment(job_, childEnv);
       addEnvironment(childEnv, job_.get("stream.addenvironment"));
-      // add TMPDIR environment variable with the value of java.io.tmpdir
+      // add TMPDIR environment VARRRRRRRRiable with the value of java.io.tmpdir
       envPut(childEnv, "TMPDIR", System.getProperty("java.io.tmpdir"));
 
       // Start the process
@@ -240,18 +240,18 @@ public abstract class PipeMapRed {
     while (it.hasNext()) {
       Map.Entry en = (Map.Entry) it.next();
       String name = (String) en.getKey();
-      //String value = (String)en.getValue(); // does not apply variable expansion
-      String value = conf.get(name); // does variable expansion 
+      //String value = (String)en.getValue(); // does not apply VARRRRRRRRiable expansion
+      String value = conf.get(name); // does VARRRRRRRRiable expansion 
       name = safeEnvVarName(name);
       envPut(env, name, value);
     }
   }
 
-  String safeEnvVarName(String var) {
+  String safeEnvVarName(String VARRRRRRRR) {
     StringBuffer safe = new StringBuffer();
-    int len = var.length();
+    int len = VARRRRRRRR.length();
     for (int i = 0; i < len; i++) {
-      char c = var.charAt(i);
+      char c = VARRRRRRRR.charAt(i);
       char s;
       if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
         s = c;
@@ -563,8 +563,8 @@ public abstract class PipeMapRed {
     return s;
   }
 
-  String envline(String var) {
-    return var + "=" + StreamUtil.env().get(var) + "\n";
+  String envline(String VARRRRRRRR) {
+    return VARRRRRRRR + "=" + StreamUtil.env().get(VARRRRRRRR) + "\n";
   }
 
   String numRecInfo() {

--- a/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamJob.java
+++ b/hadoop-tools/hadoop-streaming/src/main/java/org/apache/hadoop/streaming/StreamJob.java
@@ -434,7 +434,7 @@ public class StreamJob implements Tool {
                    "spec", 1, false);
 
     Option cmdenv =
-      createOption("cmdenv", "(n=v) Pass env.var to streaming commands.",
+      createOption("cmdenv", "(n=v) Pass env.VARRRRRRRR to streaming commands.",
                    "spec", 1, false);
     Option cacheFile = createOption("cacheFile",
                                     "File name URI", "fileNameURI", Integer.MAX_VALUE, false);
@@ -515,7 +515,7 @@ public class StreamJob implements Tool {
         + "tasks.");
     System.out.println("  -inputreader    <spec> Optional. Input recordreader"
         + " spec.");
-    System.out.println("  -cmdenv         <n>=<v> Optional. Pass env.var to"
+    System.out.println("  -cmdenv         <n>=<v> Optional. Pass env.VARRRRRRRR to"
         + " streaming commands.");
     System.out.println("  -mapdebug       <cmd> Optional. "
         + "To run this script when a map task fails.");
@@ -602,7 +602,7 @@ public class StreamJob implements Tool {
         "/path/my-hadoop-streaming.jar");
     System.out.println("For more details about jobconf parameters see:");
     System.out.println("  http://wiki.apache.org/hadoop/JobConfFile");
-    System.out.println("To set an environement variable in a streaming " +
+    System.out.println("To set an environement VARRRRRRRRiable in a streaming " +
         "command:");
     System.out.println("   -cmdenv EXAMPLE_DIR=/home/example/dictionaries/");
     System.out.println();
@@ -632,7 +632,7 @@ public class StreamJob implements Tool {
   protected String getHadoopClientHome() {
     String h = env_.getProperty("HADOOP_PREFIX"); // standard Hadoop
     if (h == null) {
-      //fail("Missing required environment variable: HADOOP_PREFIX");
+      //fail("Missing required environment VARRRRRRRRiable: HADOOP_PREFIX");
       h = "UNDEF";
     }
     return h;
@@ -1069,7 +1069,7 @@ public class StreamJob implements Tool {
   protected String ioSpec_;
   protected boolean lazyOutput_;
 
-  // Use to communicate config to the external processes (ex env.var.HADOOP_USER)
+  // Use to communicate config to the external processes (ex env.VARRRRRRRR.HADOOP_USER)
   // encoding "a=b c=d"
   protected String addTaskEnvironment_;
 

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamingTaskLog.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/TestStreamingTaskLog.java
@@ -133,7 +133,7 @@ public class TestStreamingTaskLog {
     returnStatus = job.go();
     assertEquals("StreamJob failed.", 0, returnStatus);
     
-    // validate environment variables set for the child(script) of java process
+    // validate environment VARRRRRRRRiables set for the child(script) of java process
     String env = MapReduceTestUtil.readOutput(outputPath, mr.createJobConf());
     long logSize = USERLOG_LIMIT_KB * 1024;
     assertTrue("environment set for child is wrong", env.contains("INFO,CLA")

--- a/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/UtilTest.java
+++ b/hadoop-tools/hadoop-streaming/src/test/java/org/apache/hadoop/streaming/UtilTest.java
@@ -98,23 +98,23 @@ class UtilTest {
   }
 
   public static String makeJavaCommand(Class<?> main, String[] argv) {
-    ArrayList<String> vargs = new ArrayList<String>();
+    ArrayList<String> VARRRRRRRRgs = new ArrayList<String>();
     File javaHomeBin = new File(System.getProperty("java.home"), "bin");
     File jvm = new File(javaHomeBin, "java");
-    vargs.add(jvm.toString());
+    VARRRRRRRRgs.add(jvm.toString());
     // copy parent classpath
-    vargs.add("-classpath");
-    vargs.add("\"" + System.getProperty("java.class.path") + "\"");
+    VARRRRRRRRgs.add("-classpath");
+    VARRRRRRRRgs.add("\"" + System.getProperty("java.class.path") + "\"");
   
     // add heap-size limit
-    vargs.add("-Xmx" + Runtime.getRuntime().maxMemory());
+    VARRRRRRRRgs.add("-Xmx" + Runtime.getRuntime().maxMemory());
   
     // Add main class and its arguments
-    vargs.add(main.getName());
+    VARRRRRRRRgs.add(main.getName());
     for (int i = 0; i < argv.length; i++) {
-      vargs.add(argv[i]);
+      VARRRRRRRRgs.add(argv[i]);
     }
-    return collate(vargs, " ");
+    return collate(VARRRRRRRRgs, " ");
   }
 
   public static boolean isCygwin() {


### PR DESCRIPTION
Week year is intended to be used for week dates, eg 2015-W01-1, it is often mistakenly used for calendar dates, in which case the year may be incorrect during the last week of the year

[_Created by Sourcegraph campaign `mrnugget/fix-misused-weekyear`._](https://sourcegraph.test:3443/users/mrnugget/campaigns/fix-misused-weekyear)