### PR TITLE
Remove empty catch statements

### DIFF
--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileUnsortedByteArrays.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/file/tfile/TestTFileUnsortedByteArrays.java
@@ -92,10 +92,7 @@ public class TestTFileUnsortedByteArrays extends TestCase {
           reader.createScannerByKey("aaa".getBytes(), "zzz".getBytes());
       Assert
           .fail("Failed to catch creating scanner with keys on unsorted file.");
-    }
-    catch (RuntimeException e) {
-    }
-    finally {
+    } finally {
       reader.close();
     }
   }
@@ -192,33 +189,21 @@ public class TestTFileUnsortedByteArrays extends TestCase {
       try {
         scanner.lowerBound("keyN".getBytes());
         Assert.fail("Cannot search in a unsorted TFile!");
-      }
-      catch (Exception e) {
-        // noop, expecting excetions
-      }
-      finally {
+      } finally {
       }
 
       // can't find higher
       try {
         scanner.upperBound("keyA".getBytes());
         Assert.fail("Cannot search higher in a unsorted TFile!");
-      }
-      catch (Exception e) {
-        // noop, expecting excetions
-      }
-      finally {
+      } finally {
       }
 
       // can't seek
       try {
         scanner.seekTo("keyM".getBytes());
         Assert.fail("Cannot search a unsorted TFile!");
-      }
-      catch (Exception e) {
-        // noop, expecting excetions
-      }
-      finally {
+      } finally {
       }
     }
     finally {

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSOutputStream.java
@@ -593,7 +593,6 @@ class DFSOutputStream extends FSOutputSummer implements Syncable {
         try {
           response.close();
           response.join();
-        } catch (InterruptedException  e) {
         } finally {
           response = null;
         }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFS.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/server/blockmanagement/TestBlockTokenWithDFS.java
@@ -160,7 +160,6 @@ public class TestBlockTokenWithDFS {
       if (s != null) {
         try {
           s.close();
-        } catch (IOException iex) {
         } finally {
           s = null;
         }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestYarnClientProtocolProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestYarnClientProtocolProvider.java
@@ -49,8 +49,6 @@ public class TestYarnClientProtocolProvider extends TestCase {
       cluster = new Cluster(conf);
       ClientProtocol client = cluster.getClient();
       assertTrue(client instanceof YARNRunner);
-    } catch (IOException e) {
-
     } finally {
       if (cluster != null) {
         cluster.close();

--- a/hadoop-mapreduce-project/src/contrib/gridmix/src/test/org/apache/hadoop/mapred/gridmix/TestResourceUsageEmulators.java
+++ b/hadoop-mapreduce-project/src/contrib/gridmix/src/test/org/apache/hadoop/mapred/gridmix/TestResourceUsageEmulators.java
@@ -105,8 +105,6 @@ public class TestResourceUsageEmulators {
         
         touchPath = getFilePath(getIdentifier());
         fs.delete(touchPath, false);
-      } catch (Exception e) {
-        
       } finally {
         if (fs != null) {
           try {

--- a/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/TestSlive.java
+++ b/hadoop-mapreduce-project/src/test/mapred/org/apache/hadoop/fs/slive/TestSlive.java
@@ -476,8 +476,6 @@ public class TestSlive {
     try {
       in = new DataInputStream(new FileInputStream(fn));
       vout = vf.verifyFile(byteAm, in);
-    } catch (Exception e) {
-
     } finally {
       if(in != null) in.close();
     }


### PR DESCRIPTION
Find try-catch-finally statements where the catch statement has no body (the catch clause could be omitted)

[_Created by Sourcegraph batch change `christine/java-remove-catch`._](https://demo.sourcegraph.com/users/christine/batch-changes/java-remove-catch)